### PR TITLE
Update highlight colors to be more distinguishable

### DIFF
--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -576,8 +576,9 @@ impl FormattedChunk {
                     Level::Error => {
                         w.set_style(Style::new().text(Color::Red).intense(true))?;
                     }
-                    Level::Warn => w.set_style(Style::new().text(Color::Red))?,
-                    Level::Info => w.set_style(Style::new().text(Color::Blue))?,
+                    Level::Warn => w.set_style(Style::new().text(Color::Yellow))?,
+                    Level::Info => w.set_style(Style::new().text(Color::Green))?,
+                    Level::Trace => w.set_style(Style::new().text(Color::Black).intense(true))?,
                     _ => {}
                 }
                 for chunk in chunks {


### PR DESCRIPTION
The current highlight colors are really hard to distinguish especially WARN and ERROR which are both red. This PR simply changes the colors to be the same as `env_logger`

* `ERROR` is still intense red
* `WARN` is now Yellow
* `INFO` is now Green
* `TRACE` is now intense black
* `DEBUG` is still white