### PR TITLE
Fix 'use of undeclared type or module encode' error

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -105,8 +105,7 @@ use crate::{append::AppenderConfig, config};
 #[allow(unused_imports)]
 use crate::append;
 
-#[cfg(feature = "json_encoder")]
-#[cfg(feature = "pattern_encoder")]
+#[cfg(any(feature = "json_encoder", feature = "pattern_encoder"))]
 use crate::encode;
 
 #[cfg(feature = "threshold_filter")]


### PR DESCRIPTION
...if `json_encoder` or `pattern_encoder` specified but not both.