### PR TITLE
Closure appender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
 threshold_filter = []
 background_rotation = []
-closure=["file"]
+closure=["file", "parking_lot", "pattern_encoder"]
 
 
 all_components = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
 threshold_filter = []
 background_rotation = []
+windbg = []
 
 all_components = [
     "console_appender",
@@ -60,7 +61,7 @@ fnv = "1.0"
 humantime = { version = "1.0", optional = true }
 log = { version = "0.4.0", features = ["std"] }
 log-mdc = { version = "0.1", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"]}
 serde_derive = { version = "1.0", optional = true }
 serde-value = { version = "0.6", optional = true }
 thread-id = { version = "3.3", optional = true }
@@ -72,7 +73,7 @@ serde-xml-rs = { version = "0.4", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon"] }
+winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon","debugapi"] }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2", optional = true }
@@ -90,3 +91,5 @@ required-features = ["json_encoder", "console_appender"]
 [[example]]
 name = "log_to_file"
 required-features = ["console_appender", "file_appender", "rolling_file_appender"]
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
 threshold_filter = []
 background_rotation = []
-windbg = []
+
+
 
 all_components = [
     "console_appender",
@@ -48,6 +49,9 @@ all_components = [
 ]
 
 gzip = ["flate2"]
+
+#[target.'cfg(windows)'.features]
+windbg = ["winapi"]
 
 [[bench]]
 name = "rotation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,7 @@ all_components = [
 
 gzip = ["flate2"]
 
-#[target.'cfg(windows)'.features]
-windbg = ["winapi"]
+windbg = []
 
 [[bench]]
 name = "rotation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
 threshold_filter = []
 background_rotation = []
-
+closure=["file"]
 
 
 all_components = [

--- a/src/append/closure.rs
+++ b/src/append/closure.rs
@@ -3,11 +3,11 @@
 //! send output to an arbitray closure
 //!
 //!
-//! 
+//!
 use std::any::Any;
-use std::io::Write;
 use std::cell::RefCell;
 use std::error::Error;
+use std::io::Write;
 
 use crate::append::dedup::{DeDuper, DedupResult};
 use crate::append::Append;
@@ -38,7 +38,7 @@ impl ClosureAppender {
         }
     }
     /// programmatically set the closue if using a config file
-    /// 
+    ///
     pub fn closure(conf: &crate::config::Config, name: &str, func: LogFunc) {
         let apps = conf.appenders();
         if let Some(c) = apps.iter().find(|&x| x.name() == name) {
@@ -174,7 +174,7 @@ impl ClosureAppenderBuilder {
             }
         };
         Ok(ClosureAppender {
-            deduper: deduper,
+            deduper,
             encoder: self
                 .encoder
                 .unwrap_or_else(|| Box::new(PatternEncoder::default())),

--- a/src/append/closure.rs
+++ b/src/append/closure.rs
@@ -1,12 +1,13 @@
-//! The windbg appender.
+//! The closure appender.
 //!
-//! send output to OutputDebugStringA
+//! send output to an arbitray closure
 //!
 //!
+//! 
 use std::any::Any;
-use std::error::Error;
-use std::ffi::CString;
 use std::io::Write;
+use std::cell::RefCell;
+use std::error::Error;
 
 use crate::append::dedup::{DeDuper, DedupResult};
 use crate::append::Append;
@@ -14,33 +15,46 @@ use crate::encode::EncoderConfig;
 use crate::encode::{pattern::PatternEncoder, Encode};
 use crate::file::Deserializers;
 use log::Record;
-
 use parking_lot::Mutex;
 use serde::Deserialize;
-use winapi::um::debugapi::OutputDebugStringA;
 
 /// the windbg appender
 ///
-pub struct WinDbgAppender {
+pub struct ClosureAppender {
     deduper: Option<Mutex<DeDuper>>,
     encoder: Box<dyn Encode>,
-    writer: Mutex<WinDbgWriter>,
+    writer: Mutex<RefCell<ClosureWriter>>,
 }
 
-impl WinDbgAppender {
-    /// windbg builder
+type LogFunc = Box<dyn Fn(Vec<u8>) + Send + Sync>;
+impl ClosureAppender {
+    /// closure builder
     ///
-    pub fn builder() -> WinDbgAppenderBuilder {
-        WinDbgAppenderBuilder {
+    pub fn builder() -> ClosureAppenderBuilder {
+        ClosureAppenderBuilder {
             encoder: None,
             dedup: false,
+            func: None,
         }
+    }
+    /// programmatically set the closue if using a config file
+    /// 
+    pub fn closure(conf: &crate::config::Config, name: &str, func: LogFunc) {
+        let apps = conf.appenders();
+        if let Some(c) = apps.iter().find(|&x| x.name() == name) {
+            if let Some(cla) = c.appender().as_any().downcast_ref::<ClosureAppender>() {
+                let wr = cla.writer.lock();
+                wr.borrow_mut().func.replace(func);
+            };
+        };
     }
 }
 
-impl Append for WinDbgAppender {
+impl Append for ClosureAppender {
     fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>> {
-        let mut wr = self.writer.lock();
+        let l = self.writer.lock();
+        let mut wr = l.borrow_mut();
+
         if let Some(dd) = &self.deduper {
             if dd.lock().dedup(&mut *wr, &*self.encoder, record)? == DedupResult::Skip {
                 return Ok(());
@@ -52,21 +66,27 @@ impl Append for WinDbgAppender {
         Ok(())
     }
     fn flush(&self) {}
-    fn as_any(&self)->&dyn Any{self}
-}
-
-impl std::fmt::Debug for WinDbgAppender {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
-        fmt.debug_struct("WinDbgAppender").finish()
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 
-#[derive(Default, Debug)]
-struct WinDbgWriter {
-    buf: Vec<u8>,
+impl std::fmt::Debug for ClosureAppender {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("ClosureAppender").finish()
+    }
 }
 
-impl std::io::Write for WinDbgWriter {
+struct ClosureWriter {
+    buf: Vec<u8>,
+    func: Option<LogFunc>,
+}
+impl std::fmt::Debug for ClosureWriter {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("ClosureWriter").finish()
+    }
+}
+impl std::io::Write for ClosureWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.buf.extend_from_slice(buf);
         Ok(buf.len())
@@ -74,41 +94,40 @@ impl std::io::Write for WinDbgWriter {
     fn flush(&mut self) -> std::io::Result<()> {
         let mut t = vec![];
         t.extend_from_slice(&self.buf);
-        unsafe {
-            let str = CString::new(t).unwrap();
-            OutputDebugStringA(str.as_ptr());
+        if let Some(ref f) = self.func {
+            f(t);
         }
         self.buf.clear();
         Ok(())
     }
 }
 
-impl crate::encode::Write for WinDbgWriter {}
+impl crate::encode::Write for ClosureWriter {}
 
 #[derive(Deserialize)]
-/// windbg config
+/// closure config
 /// encode is standard option
 /// dedup asks for message dedupping
 ///
-pub struct WinDbgConfig {
+pub struct ClosureConfig {
     encoder: Option<EncoderConfig>,
     dedup: Option<bool>,
 }
 
-/// windbg deseriazlier
+/// closure deseriazlier
 /// move along, nothing intersing here
-pub struct WinDbgAppenderDeserializer;
+pub struct ClosureAppenderDeserializer;
 
-impl crate::file::Deserialize for WinDbgAppenderDeserializer {
+impl crate::file::Deserialize for ClosureAppenderDeserializer {
     type Trait = dyn Append;
-    type Config = WinDbgConfig;
+    type Config = ClosureConfig;
 
     fn deserialize(
         &self,
-        config: WinDbgConfig,
+        config: ClosureConfig,
         deserializers: &Deserializers,
     ) -> Result<Box<dyn Append>, Box<dyn Error + Sync + Send>> {
-        let mut appender = WinDbgAppender::builder();
+        let mut appender = ClosureAppender::builder();
         if let Some(dedup) = config.dedup {
             appender = appender.dedup(dedup);
         }
@@ -118,29 +137,35 @@ impl crate::file::Deserialize for WinDbgAppenderDeserializer {
         Ok(Box::new(appender.build()?))
     }
 }
-/// A builder for `windbgappender`s.
+/// A builder for `closureappender`s.
 ///
-pub struct WinDbgAppenderBuilder {
+pub struct ClosureAppenderBuilder {
     encoder: Option<Box<dyn Encode>>,
     dedup: bool,
+    func: Option<LogFunc>,
 }
 
-/// windbg builder
+/// closure builder
+/// must set closure
 /// only option is dedup (boolean)
-impl WinDbgAppenderBuilder {
+impl ClosureAppenderBuilder {
     /// dedup or not
-    pub fn dedup(mut self, dedup: bool) -> WinDbgAppenderBuilder {
+    pub fn dedup(mut self, dedup: bool) -> ClosureAppenderBuilder {
         self.dedup = dedup;
         self
     }
     /// encoder
-    pub fn encoder(mut self, encoder: Box<dyn Encode>) -> WinDbgAppenderBuilder {
+    pub fn encoder(mut self, encoder: Box<dyn Encode>) -> ClosureAppenderBuilder {
         self.encoder = Some(encoder);
         self
     }
-
+    /// closure
+    pub fn closure(mut self, func: LogFunc) -> ClosureAppenderBuilder {
+        self.func = Some(func);
+        self
+    }
     /// build
-    pub fn build(self) -> std::io::Result<WinDbgAppender> {
+    pub fn build(self) -> std::io::Result<ClosureAppender> {
         let deduper = {
             if self.dedup {
                 Some(Mutex::new(DeDuper::default()))
@@ -148,12 +173,15 @@ impl WinDbgAppenderBuilder {
                 None
             }
         };
-        Ok(WinDbgAppender {
+        Ok(ClosureAppender {
             deduper: deduper,
             encoder: self
                 .encoder
                 .unwrap_or_else(|| Box::new(PatternEncoder::default())),
-            writer: Mutex::new(WinDbgWriter::default()),
+            writer: Mutex::new(RefCell::new(ClosureWriter {
+                buf: Vec::with_capacity(100),
+                func: self.func,
+            })),
         })
     }
 }

--- a/src/append/console.rs
+++ b/src/append/console.rs
@@ -1,10 +1,10 @@
 //! The console appender.
 //!
 //! Requires the `console_appender` feature.
-use std::any::Any;
 use log::Record;
 #[cfg(feature = "file")]
 use serde_derive::Deserialize;
+use std::any::Any;
 use std::{
     error::Error,
     fmt,
@@ -131,7 +131,9 @@ impl Append for ConsoleAppender {
     }
 
     fn flush(&self) {}
-    fn as_any(&self)->&dyn Any{self}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl ConsoleAppender {

--- a/src/append/console.rs
+++ b/src/append/console.rs
@@ -1,7 +1,7 @@
 //! The console appender.
 //!
 //! Requires the `console_appender` feature.
-
+use std::any::Any;
 use log::Record;
 #[cfg(feature = "file")]
 use serde_derive::Deserialize;
@@ -131,6 +131,7 @@ impl Append for ConsoleAppender {
     }
 
     fn flush(&self) {}
+    fn as_any(&self)->&dyn Any{self}
 }
 
 impl ConsoleAppender {

--- a/src/append/dedup.rs
+++ b/src/append/dedup.rs
@@ -5,7 +5,7 @@ use crate::append::Error;
 use crate::encode::{Encode, Write};
 use log::Record;
 
-const REPEAT_COUNT:i32 = 1000;
+const REPEAT_COUNT: i32 = 1000;
 
 #[derive(Default)]
 /// The file appender.
@@ -29,7 +29,6 @@ pub enum DedupResult {
     Write,
 }
 impl DeDuper {
-
     // emits the extra line saying 'last line repeated n times'
     fn say(
         w: &mut dyn Write,
@@ -49,9 +48,9 @@ impl DeDuper {
                 .build(),
         )
     }
-/// The file appender.
-///
-/// Requires the `file_appender` feature.
+    /// The file appender.
+    ///
+    /// Requires the `file_appender` feature.
     pub fn dedup(
         &mut self,
         w: &mut dyn Write,
@@ -63,7 +62,7 @@ impl DeDuper {
             self.count += 1;
 
             // every now and then keep saying we saw lots of dups
-            if self.count % REPEAT_COUNT == 0{
+            if self.count % REPEAT_COUNT == 0 {
                 Self::say(w, encoder, record, self.count)?;
             }
             return Ok(DedupResult::Skip);

--- a/src/append/dedup.rs
+++ b/src/append/dedup.rs
@@ -65,7 +65,7 @@ impl DeDuper {
             if self.count % REPEAT_COUNT == 0 {
                 Self::say(w, encoder, record, self.count)?;
             }
-            return Ok(DedupResult::Skip);
+            Ok(DedupResult::Skip)
         } else {
             self.last = msg;
             let svct = self.count;
@@ -73,7 +73,7 @@ impl DeDuper {
             if svct > 0 {
                 Self::say(w, encoder, record, svct)?;
             }
-            return Ok(DedupResult::Write);
+            Ok(DedupResult::Write)
         }
     }
 }

--- a/src/append/dedup.rs
+++ b/src/append/dedup.rs
@@ -1,0 +1,65 @@
+use crate::append::Error;
+use crate::encode::{Encode, Write};
+use log::Record;
+
+const REPEAT_COUNT:i32 = 1000;
+
+#[derive(Default)]
+pub struct DeDuper {
+    count: i32,
+    last: String,
+}
+
+#[derive(PartialEq)]
+pub enum DedupResult {
+    Skip,
+    Write,
+}
+impl DeDuper {
+
+    // emits the extra line saying 'last line repeated n times'
+    fn say(
+        w: &mut dyn Write,
+        encoder: &dyn Encode,
+        record: &Record,
+        n: i32,
+    ) -> Result<(), Box<dyn Error + Sync + Send>> {
+        encoder.encode(
+            w,
+            &Record::builder()
+                .args(format_args!("last message repeated {} times", n))
+                .level(record.level())
+                .target(record.target())
+                .module_path_static(None)
+                .file_static(None)
+                .line(None)
+                .build(),
+        )
+    }
+
+    pub fn dedup(
+        &mut self,
+        w: &mut dyn Write,
+        encoder: &dyn Encode,
+        record: &Record,
+    ) -> Result<DedupResult, Box<dyn Error + Sync + Send>> {
+        let msg = format!("{}", *record.args());
+        if msg == self.last {
+            self.count += 1;
+
+            // every now and then keep saying we saw lots of dups
+            if self.count % REPEAT_COUNT == 0{
+                Self::say(w, encoder, record, self.count)?;
+            }
+            return Ok(DedupResult::Skip);
+        } else {
+            self.last = msg;
+            let svct = self.count;
+            self.count = 0;
+            if svct > 0 {
+                Self::say(w, encoder, record, svct)?;
+            }
+            return Ok(DedupResult::Write);
+        }
+    }
+}

--- a/src/append/dedup.rs
+++ b/src/append/dedup.rs
@@ -1,3 +1,6 @@
+//! The file appender.
+//!
+//! Requires the `file_appender` feature.
 use crate::append::Error;
 use crate::encode::{Encode, Write};
 use log::Record;
@@ -5,14 +8,24 @@ use log::Record;
 const REPEAT_COUNT:i32 = 1000;
 
 #[derive(Default)]
+/// The file appender.
+///
+/// Requires the `file_appender` feature.
+
 pub struct DeDuper {
     count: i32,
     last: String,
 }
-
 #[derive(PartialEq)]
+
+/// The file appender.
+///
+/// Requires the `file_appender` feature.
+
 pub enum DedupResult {
+    /// skip
     Skip,
+    /// write
     Write,
 }
 impl DeDuper {
@@ -36,7 +49,9 @@ impl DeDuper {
                 .build(),
         )
     }
-
+/// The file appender.
+///
+/// Requires the `file_appender` feature.
     pub fn dedup(
         &mut self,
         w: &mut dyn Write,

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -1,7 +1,7 @@
 //! The file appender.
 //!
 //! Requires the `file_appender` feature.
-
+use std::any::Any;
 use log::Record;
 use parking_lot::Mutex;
 #[cfg(feature = "file")]
@@ -67,6 +67,7 @@ impl Append for FileAppender {
         Ok(())
     }
     fn flush(&self) {}
+    fn as_any(&self)->&dyn Any{self}
 }
 
 impl FileAppender {

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -11,7 +11,7 @@ use std::{
     fmt,
     fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
-    path::{Path, PathBuf}
+    path::{Path, PathBuf},
 };
 
 #[cfg(feature = "file")]
@@ -34,7 +34,6 @@ pub struct FileAppenderConfig {
     encoder: Option<EncoderConfig>,
     append: Option<bool>,
     dedup: Option<bool>,
-
 }
 
 /// An appender which logs to a file.
@@ -42,7 +41,7 @@ pub struct FileAppender {
     path: PathBuf,
     file: Mutex<SimpleWriter<BufWriter<File>>>,
     encoder: Box<dyn Encode>,
-    deduper: Option<Mutex<DeDuper>>
+    deduper: Option<Mutex<DeDuper>>,
 }
 
 impl fmt::Debug for FileAppender {
@@ -57,10 +56,9 @@ impl fmt::Debug for FileAppender {
 impl Append for FileAppender {
     fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>> {
         let mut file = self.file.lock();
-        if let Some(dd) = &self.deduper{
-            if dd.lock().
-            dedup(&mut *file, &*self.encoder, record)? == DedupResult::Skip{
-                return Ok(())
+        if let Some(dd) = &self.deduper {
+            if dd.lock().dedup(&mut *file, &*self.encoder, record)? == DedupResult::Skip {
+                return Ok(());
             }
         }
 
@@ -124,17 +122,16 @@ impl FileAppenderBuilder {
             .create(true)
             .open(&path)?;
         let deduper = {
-            if self.dedup{
+            if self.dedup {
                 Some(Mutex::new(DeDuper::default()))
-            }
-            else {
+            } else {
                 None
             }
         };
         Ok(FileAppender {
             path,
             file: Mutex::new(SimpleWriter(BufWriter::with_capacity(1024, file))),
-            deduper:deduper,
+            deduper: deduper,
             encoder: self
                 .encoder
                 .unwrap_or_else(|| Box::new(PatternEncoder::default())),

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -131,7 +131,7 @@ impl FileAppenderBuilder {
         Ok(FileAppender {
             path,
             file: Mutex::new(SimpleWriter(BufWriter::with_capacity(1024, file))),
-            deduper: deduper,
+            deduper,
             encoder: self
                 .encoder
                 .unwrap_or_else(|| Box::new(PatternEncoder::default())),

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -12,6 +12,7 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
     path::{Path, PathBuf},
+    cell::{RefCell}
 };
 
 #[cfg(feature = "file")]
@@ -23,6 +24,8 @@ use crate::{
     encode::{pattern::PatternEncoder, writer::simple::SimpleWriter, Encode},
 };
 
+use crate::append::dedup::*;
+
 /// The file appender's configuration.
 #[cfg(feature = "file")]
 #[derive(Deserialize)]
@@ -31,6 +34,8 @@ pub struct FileAppenderConfig {
     path: String,
     encoder: Option<EncoderConfig>,
     append: Option<bool>,
+    dedup: Option<bool>,
+
 }
 
 /// An appender which logs to a file.
@@ -38,6 +43,7 @@ pub struct FileAppender {
     path: PathBuf,
     file: Mutex<SimpleWriter<BufWriter<File>>>,
     encoder: Box<dyn Encode>,
+    deduper: Option<Mutex<RefCell<DeDuper>>>
 }
 
 impl fmt::Debug for FileAppender {
@@ -52,11 +58,14 @@ impl fmt::Debug for FileAppender {
 impl Append for FileAppender {
     fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>> {
         let mut file = self.file.lock();
+        if let Some(dd) = &self.deduper{
+            if dd.lock().borrow_mut().dedup(&mut *file, &*self.encoder, record)? == DedupResult::Skip{return Ok(())}
+        }
+
         self.encoder.encode(&mut *file, record)?;
         file.flush()?;
         Ok(())
     }
-
     fn flush(&self) {}
 }
 
@@ -66,6 +75,7 @@ impl FileAppender {
         FileAppenderBuilder {
             encoder: None,
             append: true,
+            dedup: false,
         }
     }
 }
@@ -74,6 +84,7 @@ impl FileAppender {
 pub struct FileAppenderBuilder {
     encoder: Option<Box<dyn Encode>>,
     append: bool,
+    dedup: bool,
 }
 
 impl FileAppenderBuilder {
@@ -90,6 +101,13 @@ impl FileAppenderBuilder {
         self.append = append;
         self
     }
+    /// Determines if the appender will reject and count duplicate messages.
+    ///
+    /// Defaults to `false`.
+    pub fn dedup(mut self, dedup: bool) -> FileAppenderBuilder {
+        self.dedup = dedup;
+        self
+    }
 
     /// Consumes the `FileAppenderBuilder`, producing a `FileAppender`.
     pub fn build<P: AsRef<Path>>(self, path: P) -> io::Result<FileAppender> {
@@ -103,10 +121,18 @@ impl FileAppenderBuilder {
             .truncate(!self.append)
             .create(true)
             .open(&path)?;
-
+        let deduper = {
+            if self.dedup{
+                Some(Mutex::new(RefCell::new(DeDuper::default())))
+            }
+            else {
+                None
+            }
+        };
         Ok(FileAppender {
             path,
             file: Mutex::new(SimpleWriter(BufWriter::with_capacity(1024, file))),
+            deduper:deduper,
             encoder: self
                 .encoder
                 .unwrap_or_else(|| Box::new(PatternEncoder::default())),
@@ -149,6 +175,9 @@ impl Deserialize for FileAppenderDeserializer {
         let mut appender = FileAppender::builder();
         if let Some(append) = config.append {
             appender = appender.append(append);
+        }
+        if let Some(dedup) = config.dedup {
+            appender = appender.dedup(dedup);
         }
         if let Some(encoder) = config.encoder {
             appender = appender.encoder(deserializers.deserialize(&encoder.kind, encoder.config)?);

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -1,11 +1,11 @@
 //! The file appender.
 //!
 //! Requires the `file_appender` feature.
-use std::any::Any;
 use log::Record;
 use parking_lot::Mutex;
 #[cfg(feature = "file")]
 use serde_derive::Deserialize;
+use std::any::Any;
 use std::{
     error::Error,
     fmt,
@@ -67,7 +67,9 @@ impl Append for FileAppender {
         Ok(())
     }
     fn flush(&self) {}
-    fn as_any(&self)->&dyn Any{self}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl FileAppender {

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -1,5 +1,5 @@
 //! Appenders
-
+use std::any::Any;
 use log::{Log, Record};
 #[cfg(feature = "file")]
 use serde::{de, Deserialize, Deserializer};
@@ -22,6 +22,7 @@ pub mod file;
 pub mod rolling_file;
 
 pub mod dedup;
+pub mod closure;
 #[cfg(all(target_os = "windows", feature = "windbg"))]
 pub mod windbg;
 /// A trait implemented by log4rs appenders.
@@ -34,6 +35,8 @@ pub trait Append: fmt::Debug + Send + Sync + 'static {
 
     /// Flushes all in-flight records.
     fn flush(&self);
+    /// private
+    fn as_any(&self)->&dyn Any;
 }
 
 #[cfg(feature = "file")]
@@ -52,6 +55,7 @@ impl<T: Log + fmt::Debug + 'static> Append for T {
     fn flush(&self) {
         Log::flush(self)
     }
+    fn as_any(&self)->&dyn Any{self}
 }
 
 /// Configuration for an appender.

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -20,7 +20,8 @@ pub mod console;
 pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
-#[cfg(feature = "windbg")]
+
+#[cfg(all(target_os = "windows", feature = "windbg"))]
 pub mod windbg;
 pub mod dedup;
 /// A trait implemented by log4rs appenders.

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -14,15 +14,15 @@ use crate::file::Deserializable;
 #[cfg(feature = "file")]
 use crate::filter::FilterConfig;
 
+#[cfg(feature = "closure")]
+pub mod closure;
 #[cfg(feature = "console_appender")]
 pub mod console;
+pub mod dedup;
 #[cfg(feature = "file_appender")]
 pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
-
-pub mod closure;
-pub mod dedup;
 #[cfg(all(target_os = "windows", feature = "windbg"))]
 pub mod windbg;
 /// A trait implemented by log4rs appenders.

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -21,6 +21,7 @@ pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
 
+mod dedup;
 /// A trait implemented by log4rs appenders.
 ///
 /// Appenders take a log record and processes them, for example, by writing it

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -20,8 +20,9 @@ pub mod console;
 pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
-
-mod dedup;
+#[cfg(feature = "windbg")]
+pub mod windbg;
+pub mod dedup;
 /// A trait implemented by log4rs appenders.
 ///
 /// Appenders take a log record and processes them, for example, by writing it

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -1,10 +1,10 @@
 //! Appenders
-use std::any::Any;
 use log::{Log, Record};
 #[cfg(feature = "file")]
 use serde::{de, Deserialize, Deserializer};
 #[cfg(feature = "file")]
 use serde_value::Value;
+use std::any::Any;
 #[cfg(feature = "file")]
 use std::collections::BTreeMap;
 use std::{error::Error, fmt};
@@ -21,8 +21,8 @@ pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
 
-pub mod dedup;
 pub mod closure;
+pub mod dedup;
 #[cfg(all(target_os = "windows", feature = "windbg"))]
 pub mod windbg;
 /// A trait implemented by log4rs appenders.
@@ -36,7 +36,7 @@ pub trait Append: fmt::Debug + Send + Sync + 'static {
     /// Flushes all in-flight records.
     fn flush(&self);
     /// private
-    fn as_any(&self)->&dyn Any;
+    fn as_any(&self) -> &dyn Any;
 }
 
 #[cfg(feature = "file")]
@@ -55,7 +55,9 @@ impl<T: Log + fmt::Debug + 'static> Append for T {
     fn flush(&self) {
         Log::flush(self)
     }
-    fn as_any(&self)->&dyn Any{self}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 /// Configuration for an appender.

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -21,9 +21,9 @@ pub mod file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
 
+pub mod dedup;
 #[cfg(all(target_os = "windows", feature = "windbg"))]
 pub mod windbg;
-pub mod dedup;
 /// A trait implemented by log4rs appenders.
 ///
 /// Appenders take a log record and processes them, for example, by writing it

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -15,13 +15,13 @@
 //! reaches 50 megabytes, and to preserve the last 10 log files.
 //!
 //! Requires the `rolling_file_appender` feature.
-use std::any::Any;
 use log::Record;
 use parking_lot::Mutex;
 #[cfg(feature = "file")]
 use serde_derive::Deserialize;
 #[cfg(feature = "file")]
 use serde_value::Value;
+use std::any::Any;
 #[cfg(feature = "file")]
 use std::collections::BTreeMap;
 use std::{
@@ -192,7 +192,9 @@ impl Append for RollingFileAppender {
     }
 
     fn flush(&self) {}
-    fn as_any(&self)->&dyn Any{self}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl RollingFileAppender {

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -15,7 +15,7 @@
 //! reaches 50 megabytes, and to preserve the last 10 log files.
 //!
 //! Requires the `rolling_file_appender` feature.
-
+use std::any::Any;
 use log::Record;
 use parking_lot::Mutex;
 #[cfg(feature = "file")]
@@ -192,6 +192,7 @@ impl Append for RollingFileAppender {
     }
 
     fn flush(&self) {}
+    fn as_any(&self)->&dyn Any{self}
 }
 
 impl RollingFileAppender {

--- a/src/append/windbg.rs
+++ b/src/append/windbg.rs
@@ -1,0 +1,162 @@
+//! The windbg appender.
+//!
+//! send output to OutputDebugStringA
+//!
+//!
+
+use std::error::Error;
+use std::ffi::CString;
+use std::io::Write;
+
+use crate::append::dedup::{DeDuper, DedupResult};
+use crate::append::Append;
+use crate::encode::EncoderConfig;
+use crate::encode::{pattern::PatternEncoder, Encode};
+use crate::file::Deserializers;
+use log::Record;
+
+use parking_lot::Mutex;
+use serde::Deserialize;
+use winapi::um::debugapi::OutputDebugStringA;
+
+/// the windbg appender
+///
+pub struct WinDbgAppender {
+    deduper: Option<Mutex<DeDuper>>,
+    encoder: Box<dyn Encode>,
+    writer: Mutex<WinDbgWriter>,
+}
+
+impl WinDbgAppender {
+    /// windbg builder
+    ///
+    pub fn builder() -> WinDbgAppenderBuilder {
+        WinDbgAppenderBuilder {
+            encoder: None,
+            dedup: false,
+        }
+    }
+}
+
+impl Append for WinDbgAppender {
+    fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>> {
+        let mut wr = self.writer.lock();
+        if let Some(dd) = &self.deduper {
+            if dd
+                .lock()
+                .dedup(&mut *wr, &*self.encoder, record)?
+                == DedupResult::Skip
+            {
+                return Ok(());
+            }
+        }
+
+        self.encoder.encode(&mut *wr, record)?;
+        wr.flush()?;
+        Ok(())
+    }
+    fn flush(&self) {}
+}
+
+impl std::fmt::Debug for WinDbgAppender {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.debug_struct("WinDbgAppender").finish()
+    }
+}
+
+#[derive(Default, Debug)]
+struct WinDbgWriter {
+    buf: Vec<u8>,
+}
+
+impl std::io::Write for WinDbgWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut t = vec![];
+        t.extend_from_slice(&self.buf);
+        unsafe {
+            let str = CString::new(t).unwrap();
+            OutputDebugStringA(str.as_ptr());
+        }
+        self.buf.clear();
+        Ok(())
+    }
+}
+
+impl crate::encode::Write for WinDbgWriter {}
+
+#[derive(Deserialize)]
+/// windbg config
+/// encode is standard option
+/// dedup asks for message dedupping
+///
+pub struct WinDbgConfig {
+    encoder: Option<EncoderConfig>,
+    dedup: Option<bool>,
+}
+
+/// windbg deseriazlier
+/// move along, nothing intersing here
+pub struct WinDbgAppenderDeserializer;
+
+impl crate::file::Deserialize for WinDbgAppenderDeserializer {
+    type Trait = dyn Append;
+    type Config = WinDbgConfig;
+
+    fn deserialize(
+        &self,
+        config: WinDbgConfig,
+        deserializers: &Deserializers,
+    ) -> Result<Box<dyn Append>, Box<dyn Error + Sync + Send>> {
+        let mut appender = WinDbgAppender::builder();
+        if let Some(dedup) = config.dedup {
+            appender = appender.dedup(dedup);
+        }
+        if let Some(encoder) = config.encoder {
+            appender = appender.encoder(deserializers.deserialize(&encoder.kind, encoder.config)?);
+        }
+        Ok(Box::new(appender.build()?))
+    }
+}
+/// A builder for `windbgappender`s.
+///
+pub struct WinDbgAppenderBuilder {
+    encoder: Option<Box<dyn Encode>>,
+    dedup: bool,
+}
+
+/// windbg builder
+/// only option is dedup (boolean)
+impl WinDbgAppenderBuilder {
+    /// dedup or not
+    pub fn dedup(mut self, dedup: bool) -> WinDbgAppenderBuilder {
+        self.dedup = dedup;
+        self
+    }
+    /// encoder
+    pub fn encoder(mut self, encoder: Box<dyn Encode>) -> WinDbgAppenderBuilder {
+        self.encoder = Some(encoder);
+        self
+    }
+
+    /// build
+    pub fn build(self) -> std::io::Result<WinDbgAppender> {
+        let deduper = {
+            if self.dedup {
+                Some(Mutex::new(DeDuper::default()))
+            } else {
+                None
+            }
+        };
+        Ok(WinDbgAppender {
+            deduper: deduper,
+            encoder: self
+                .encoder
+                .unwrap_or_else(|| Box::new(PatternEncoder::default())),
+            writer: Mutex::new(WinDbgWriter::default()),
+        })
+    }
+}

--- a/src/append/windbg.rs
+++ b/src/append/windbg.rs
@@ -52,7 +52,9 @@ impl Append for WinDbgAppender {
         Ok(())
     }
     fn flush(&self) {}
-    fn as_any(&self)->&dyn Any{self}
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
 }
 
 impl std::fmt::Debug for WinDbgAppender {

--- a/src/append/windbg.rs
+++ b/src/append/windbg.rs
@@ -42,11 +42,7 @@ impl Append for WinDbgAppender {
     fn append(&self, record: &Record) -> Result<(), Box<dyn Error + Sync + Send>> {
         let mut wr = self.writer.lock();
         if let Some(dd) = &self.deduper {
-            if dd
-                .lock()
-                .dedup(&mut *wr, &*self.encoder, record)?
-                == DedupResult::Skip
-            {
+            if dd.lock().dedup(&mut *wr, &*self.encoder, record)? == DedupResult::Skip {
                 return Ok(());
             }
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -192,7 +192,9 @@ impl Default for Deserializers {
         #[cfg(all(target_os = "windows", feature = "windbg"))]
         d.insert("windbg", append::windbg::WinDbgAppenderDeserializer);
 
+        #[cfg(feature = "closure")]
         d.insert("closure", append::closure::ClosureAppenderDeserializer);
+        
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",

--- a/src/file.rs
+++ b/src/file.rs
@@ -192,7 +192,7 @@ impl Default for Deserializers {
         #[cfg(all(target_os = "windows", feature = "windbg"))]
         d.insert("windbg", append::windbg::WinDbgAppenderDeserializer);
 
-          d.insert("closure", append::closure::ClosureAppenderDeserializer);
+        d.insert("closure", append::closure::ClosureAppenderDeserializer);
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",

--- a/src/file.rs
+++ b/src/file.rs
@@ -189,11 +189,8 @@ impl Default for Deserializers {
             "rolling_file",
             append::rolling_file::RollingFileAppenderDeserializer,
         );
-        #[cfg(feature = "windbg")]
-        d.insert(
-            "windbg",
-            append::windbg::WinDbgAppenderDeserializer,
-        );
+        #[cfg(all(target_os = "windows", feature = "windbg"))]
+        d.insert("windbg", append::windbg::WinDbgAppenderDeserializer);
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",

--- a/src/file.rs
+++ b/src/file.rs
@@ -191,6 +191,8 @@ impl Default for Deserializers {
         );
         #[cfg(all(target_os = "windows", feature = "windbg"))]
         d.insert("windbg", append::windbg::WinDbgAppenderDeserializer);
+
+          d.insert("closure", append::closure::ClosureAppenderDeserializer);
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",

--- a/src/file.rs
+++ b/src/file.rs
@@ -189,7 +189,11 @@ impl Default for Deserializers {
             "rolling_file",
             append::rolling_file::RollingFileAppenderDeserializer,
         );
-
+        #[cfg(feature = "windbg")]
+        d.insert(
+            "windbg",
+            append::windbg::WinDbgAppenderDeserializer,
+        );
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",

--- a/src/file.rs
+++ b/src/file.rs
@@ -194,7 +194,6 @@ impl Default for Deserializers {
 
         #[cfg(feature = "closure")]
         d.insert("closure", append::closure::ClosureAppenderDeserializer);
-        
         #[cfg(feature = "compound_policy")]
         d.insert(
             "compound",


### PR DESCRIPTION
this allows the creation of odd appenders that are serviced via a closure. Simplifies the creation of appenders that dont need a lot of plumbing or configuration. Supports dedup. If in code

    let cl = ClosureAppender::builder()
        .encoder(Box::new(PatternEncoder::new("{d} - {m}{n}")))
        .closure(Box::new(|b| {
            let str = String::from_utf8(b).unwrap();
            print!("{}", str);
        }))
        .build()
        .unwrap();

    let config = Config::builder()
        .appender(Appender::builder().build("dbg", Box::new(cl)))
        .build(Root::builder().appender("dbg").build(LevelFilter::Trace))
        .unwrap();

    let handle = log4rs::init_config(config).unwrap();

or via config, some code needed since you cannot specify a closure in a file.

```
appenders:

  print:
    kind: closure
    dedup: true
    encoder:
      pattern: "{d(%Y-%m-%d %H:%M:%S)} {T} {f}:{L} {m}{n}"



# Set the default logging level to "warn" and attach the "stdout" appender to the root
root:
  level: warn
  appenders:
    - print
```

and then
```
    let mut conf =
        log4rs::load_config_file("c:/work/rust/logtest/log.yaml", Default::default()).unwrap();


    log4rs::append::closure::ClosureAppender::closure(
         &conf,
         "print",
         Box::new(|b| {
             let str = String::from_utf8(b).unwrap();
             print!("{}", str);
         }),
     );
     log4rs::init_config(conf);
```