### PR TITLE
pattern encoder: Set trace to default color, reset formatting after

### DIFF
--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -591,7 +591,9 @@ impl FormattedChunk {
                     chunk.encode(w, record)?;
                 }
                 match record.level() {
-                    Level::Error | Level::Warn | Level::Info | Level::Trace => w.set_style(&Style::new())?,
+                    Level::Error | Level::Warn | Level::Info | Level::Trace => {
+                        w.set_style(&Style::new())?
+                    },
                     _ => {}
                 }
                 Ok(())

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -593,7 +593,7 @@ impl FormattedChunk {
                 match record.level() {
                     Level::Error | Level::Warn | Level::Info | Level::Trace => {
                         w.set_style(&Style::new())?
-                    },
+                    }
                     _ => {}
                 }
                 Ok(())

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -584,14 +584,14 @@ impl FormattedChunk {
                     }
                     Level::Warn => w.set_style(Style::new().text(Color::Yellow))?,
                     Level::Info => w.set_style(Style::new().text(Color::Green))?,
-                    Level::Trace => w.set_style(Style::new().text(Color::Black).intense(true))?,
+                    Level::Trace => w.set_style(Style::new().intense(true))?,
                     _ => {}
                 }
                 for chunk in chunks {
                     chunk.encode(w, record)?;
                 }
                 match record.level() {
-                    Level::Error | Level::Warn | Level::Info => w.set_style(&Style::new())?,
+                    Level::Error | Level::Warn | Level::Info | Level::Trace => w.set_style(&Style::new())?,
                     _ => {}
                 }
                 Ok(())

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -584,7 +584,7 @@ impl FormattedChunk {
                     }
                     Level::Warn => w.set_style(Style::new().text(Color::Yellow))?,
                     Level::Info => w.set_style(Style::new().text(Color::Green))?,
-                    Level::Trace => w.set_style(Style::new().intense(true))?,
+                    Level::Trace => w.set_style(Style::new().text(Color::Cyan))?,
                     _ => {}
                 }
                 for chunk in chunks {


### PR DESCRIPTION
Fixes #184, makes text readable no matter the color scheme.