### PR TITLE
configurable highlight

### DIFF
--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -11,6 +11,8 @@ use std::{error::Error, fmt, io};
 
 #[cfg(feature = "file")]
 use crate::file::Deserializable;
+#[cfg(feature = "file")]
+use serde_derive::Deserialize;
 
 #[cfg(feature = "json_encoder")]
 pub mod json;
@@ -77,6 +79,20 @@ impl<'de> de::Deserialize<'de> for EncoderConfig {
 }
 
 /// A text or background color.
+#[cfg(feature = "file")]
+#[derive(Copy, Clone, Debug, Deserialize)]
+#[allow(missing_docs)]
+pub enum Color {
+    Black,
+    Red,
+    Green,
+    Yellow,
+    Blue,
+    Magenta,
+    Cyan,
+    White,
+}
+#[cfg(not(feature = "file"))]
 #[derive(Copy, Clone, Debug)]
 #[allow(missing_docs)]
 pub enum Color {

--- a/src/file.rs
+++ b/src/file.rs
@@ -575,6 +575,9 @@ appenders:
     path: /tmp/baz.log
     encoder:
       pattern: "%m"
+      color_map:
+        INFO: Blue
+        TRACE: Black
 
 root:
   appenders:


### PR DESCRIPTION
Specifically this is useful for dark console backgrounds where the default
for 'Blue' for log level INFO is difficult to read. 

Most of the changes are in `src/encode/patter/mod.rs`. I added default
parameters for deserializing. I added a function to describe the default
pattern string, and defined that at the top of the source file.
I added a `color_map` to the Encoder structs which is a HashMap that
defines the LogLovel->Color mapping. The color_map is of type
`HashMap<Level, Option<Color>>`, if the Option is None, then no styling
is applied. 

TODO: Adding a feature means adding documentation, which isn't complete.
I can do this and add to the PR, however before i continue i want to
make sure this is the direction that the maintiner wants to take.

TODO: Other testing may need to be done. I was testing with `cargo test
--features file` 
with a modified config option in the yaml test config. As i am not familiar 
with this code base there may be other cases that need to be tested.

TODO/Future: This patch only allows foreground color to be specified.
There are other aspects of styling like bold,italics,background color.
Does it make sense to allow for more detailed styling? That involves
more work and more work for the maintiner. I think forground color will
probably cover most everyone's cases.

To use, the relevant config change is as follows:
``` 
      pattern: "%m"
      color_map:
        INFO: Blue
        TRACE: Black
```

Related: issue:#17, PR:#186