### PR TITLE
fix: init_raw_config forcing max_log_level to Info

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -63,7 +63,7 @@ pub fn init_raw_config(config: RawConfig) -> Result<(), InitError> {
         .build(config.root())?;
 
     let logger = crate::Logger::new(config);
-    log::set_max_level(log::LevelFilter::Info);
+    log::set_max_level(logger.max_log_level());
     log::set_boxed_logger(Box::new(logger))?;
     Ok(())
 }


### PR DESCRIPTION
`init_raw_config` introduced in 1.0.1-alpha-1 calls `log::set_max_level` with the hardcoded value of `Info`.
This PR makes it take the max level from the deserialized config, just like `init_config` does.