### PR TITLE
WIP: Adding ability to configure colors for console

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "log4rs"
-version = "1.0.0-alpha-1"
+version = "1.0.0-alpha-2"
 authors = ["Steven Fackler <sfackler@gmail.com>", "Evan Simmons <esims89@gmail.com>"]
 description = "A highly configurable multi-output logging implementation for the `log` facade"
 license = "MIT/Apache-2.0"

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -476,6 +476,9 @@ appenders:
     path: /tmp/baz.log
     encoder:
       pattern: "%m"
+      color_map:
+        INFO: Blue
+        TRACE: Black
 
 root:
   appenders:

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -79,9 +79,9 @@ impl<'de> de::Deserialize<'de> for EncoderConfig {
 }
 
 /// A text or background color.
-#[cfg_attr(feature = "config_parsing", derive(serde::Deserialize))] 
+#[cfg_attr(feature = "config_parsing", derive(serde::Deserialize))]
 //#[cfg(feature = "config_parsing")]
-#[derive(Copy, Clone, Debug, Eq, PartialEq,Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[allow(missing_docs)]
 pub enum Color {
     Black,

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -13,6 +13,8 @@ use std::collections::BTreeMap;
 
 #[cfg(feature = "config_parsing")]
 use crate::config::Deserializable;
+#[cfg(feature = "file")]
+use crate::file::Deserializable;
 
 #[cfg(feature = "json_encoder")]
 pub mod json;
@@ -77,8 +79,10 @@ impl<'de> de::Deserialize<'de> for EncoderConfig {
 }
 
 /// A text or background color.
+#[cfg_attr(feature = "config_parsing", derive(serde::Deserialize))] 
+//#[cfg(feature = "config_parsing")]
+#[derive(Copy, Clone, Debug, Eq, PartialEq,Hash)]
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Color {
     Black,
     Red,

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -121,9 +121,9 @@
 use chrono::{Local, Utc};
 use derivative::Derivative;
 use log::{Level, Record};
-use std::{collections::HashMap, default::Default, io, process, thread};
 #[cfg(feature = "file")]
 use serde_derive::Deserialize;
+use std::{collections::HashMap, default::Default, io, process, thread};
 
 use crate::encode::{
     self,
@@ -154,7 +154,7 @@ fn default_color_map() -> HashMap<Level, Option<Color>> {
 /// The pattern encoder's configuration.
 #[cfg(feature = "config_parsing")]
 #[serde(deny_unknown_fields)]
-#[derive(Clone, Eq, PartialEq,/* Hash, */ Debug, Default, serde::Deserialize)]
+#[derive(Clone, Eq, PartialEq, Debug, Default, serde::Deserialize)]
 pub struct PatternEncoderConfig {
     #[serde(default = "default_pattern")]
     pattern: Option<String>,
@@ -638,7 +638,7 @@ impl FormattedChunk {
 /// An `Encode`r configured via a format string.
 #[derive(Derivative)]
 #[derivative(Debug)]
-#[derive(Clone, Eq, PartialEq, /*Hash*/)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct PatternEncoder {
     #[derivative(Debug = "ignore")]
     chunks: Vec<Chunk>,

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -667,11 +667,6 @@ impl Encode for PatternEncoder {
 #[cfg(feature = "file")]
 impl From<PatternEncoderConfig> for PatternEncoder {
     fn from(pattern_config: PatternEncoderConfig) -> Self {
-        // Merge default color_map with user-configured color_map
-        let mut color_map = default_color_map();
-        for (k, v) in pattern_config.color_map {
-            color_map.insert(k, v);
-        }
         PatternEncoder::new_with_colormap(&pattern_config.pattern, color_map)
     }
 }
@@ -691,14 +686,35 @@ impl PatternEncoder {
     /// Creates a `PatternEncoder` from a pattern string and color hashmap.
     ///
     /// The pattern string syntax is documented in the `pattern` module.
+    ///
+    ///
+    ///! ```no_run
+    ///! # #[cfg(all(feature = "console_appender",
+    ///! #           feature = "file_appender",
+    ///! #           feature = "pattern_encoder"))]
+    ///! # fn f() {
+    ///! // Change color of Info level msgs, other msgs will be the default color
+    ///! let mut log_color_map = HashMap::new();
+    ///! log_color_map.insert(log::Level::Info, Some(log4rs::encode::Color::Cyan));
+    ///! let pattern_encoder = PatternEncoder::new_with_colormap("{d} - {m}{n}", log_color_map);
+    ///!
+    ///! }
+    ///! # }
+    ///! # fn main() {}
+    ///! ```
     pub fn new_with_colormap(
         pattern: &str,
         color_map: HashMap<Level, Option<Color>>,
     ) -> PatternEncoder {
+        // Merge default color_map with user-configured color_map
+        let mut color_map_def = default_color_map();
+        for (k, v) in color_map {
+            color_map_def.insert(k, v);
+        }
         PatternEncoder {
             chunks: Parser::new(pattern).map(From::from).collect(),
             pattern: pattern.to_owned(),
-            color_map,
+            color_map: color_map_def,
         }
     }
 }

--- a/test/log.yml
+++ b/test/log.yml
@@ -5,6 +5,9 @@ appenders:
     kind: console
     encoder:
       pattern: "{d(%+)(local)} [{t}] {h({l})} {M}:{m}{n}"
+      color_map: 
+        Info: Cyan
+        Warn: Red
     filters:
     - kind: threshold
       level: error


### PR DESCRIPTION
Specifically this useful for dark console backgrounds where the default
for 'Blue' for log level INFO is difficult to read.

Most of the changes are in `src/encode/patter/mod.rs`. I added default
parameters for deserializing. I added a function to describe the default
pattern string, and defined that at the top of the source file.
I added a `color_map` to the Encoder structs which is a HashMap that
defines the LogLovel->Color mapping. The color_map is of type
`HashMap<Level, Option<Color>>`, if the Option is None, then no styling
is applied.

TODO: Adding a feature means adding documentation, which isn't complete.
I can do this and add to the PR, however before i continue i want to
make sure this is the direction that the maintainer wants to take.

TODO: Other testing may need to be done. I was testing with `cargo test
--features file` with a modified config option in the yaml test config.
As i am not familiar with this code base there may be other cases that
need to be tested.

TODO/Future: This patch only allows foreground color to be specified.
There are other aspects of styling like bold,italics,background color.
Does it make sense to allow for more detailed styling? That involves
more work and more work for the maintainer. I think foreground color will
probably cover most everyone's cases.

To use, the relevant config change is as follows:

```
      pattern: "%m"
      color_map:
        INFO: Blue
        TRACE: Black
```
Related: issue:#17, PR:#186, 
Continued from: PR:#194