### PR TITLE
Fix link in documentation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@
 //! # fn main() {}
 //! ```
 //!
-//! For more examples see the (examples)[https://github.com/estk/log4rs/tree/master/examples] in the source.
+//! For more examples see the [examples](https://github.com/estk/log4rs/tree/master/examples) in the source.
 //!
 
 #![allow(where_clauses_object_safety, clippy::manual_non_exhaustive)]


### PR DESCRIPTION
Just a small fix of a link found in the library documentation.