### PR TITLE
Rewrite expand_env_vars(), drop regex dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ json_format = ["serde_json"]
 toml_format = ["toml"]
 
 console_appender = ["console_writer", "simple_writer", "pattern_encoder"]
-file_appender = ["parking_lot", "simple_writer", "pattern_encoder", "regex"]
-rolling_file_appender = ["parking_lot", "simple_writer", "pattern_encoder", "regex"]
+file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
+rolling_file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
 compound_policy = []
 delete_roller = []
 fixed_window_roller = []
@@ -67,7 +67,6 @@ serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8.4", optional = true }
 toml = { version = "0.5", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
-regex = { version = "1", optional = true }
 thiserror = "1.0.15"
 anyhow = "1.0.28"
 derivative = "2.1.1"

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -29,8 +29,7 @@ mod env_util {
     pub fn expand_env_vars(path: std::path::PathBuf) -> std::path::PathBuf {
         let path: String = path.to_string_lossy().into();
         let mut outpath: String = path.clone();
-        'prefix_loop: for match_index in path.match_indices(ENV_VAR_PREFIX) {
-            let match_start = match_index.0;
+        'prefix_loop: for (match_start, _) in path.match_indices(ENV_VAR_PREFIX) {
             let (_, tail) = path.split_at(match_start + ENV_VAR_PREFIX.len());
             let mut cs = tail.chars();
             // Check first character.


### PR DESCRIPTION
The crates regex, regex_syntax, aho_coresick are all several
times bigger than log4rs itself and reg exps are only used in
one place to replace $ENV vars in paths.
Rewrite expand_env_vars() with a hand-coded scanner and
remote regex as dependency.

Closes #228 