### PR TITLE
Add support for gettid() to PatternEncoder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ delete_roller = []
 fixed_window_roller = []
 size_trigger = []
 json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "log/serde", "thread-id"]
-pattern_encoder = ["chrono", "log-mdc", "thread-id"]
+pattern_encoder = ["chrono", "log-mdc", "thread-id", "gettid"]
 ansi_writer = []
 console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
@@ -62,6 +62,7 @@ log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
 thread-id = { version = "3.3", optional = true }
+gettid = { version = "0.1", optional = true }
 typemap = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8.4", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ delete_roller = []
 fixed_window_roller = []
 size_trigger = []
 json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "log/serde", "thread-id"]
-pattern_encoder = ["chrono", "log-mdc", "thread-id", "gettid"]
+pattern_encoder = ["chrono", "log-mdc", "thread-id", "palaver"]
 ansi_writer = []
 console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
@@ -62,7 +62,7 @@ log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
 thread-id = { version = "3.3", optional = true }
-gettid = { version = "0.1", optional = true }
+palaver = { version = "0.2", optional = true }
 typemap = { version = "0.3", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8.4", optional = true }

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -28,6 +28,11 @@ const NEWLINE: &'static str = "\r\n";
 #[cfg(not(windows))]
 const NEWLINE: &str = "\n";
 
+thread_local!(
+    /// Thread-locally cached thread ID.
+    pub(crate) static TID: u64 = gettid::gettid()
+);
+
 /// A trait implemented by types that can serialize a `Record` into a
 /// `Write`r.
 ///

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -28,11 +28,6 @@ const NEWLINE: &'static str = "\r\n";
 #[cfg(not(windows))]
 const NEWLINE: &str = "\n";
 
-thread_local!(
-    /// Thread-locally cached thread ID.
-    pub(crate) static TID: u64 = gettid::gettid()
-);
-
 /// A trait implemented by types that can serialize a `Record` into a
 /// `Write`r.
 ///

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -60,10 +60,11 @@
 //! * `M`, `module` - The module that the log message came from, or `???` if not
 //!     provided.
 //! * `P`, `pid` - The current process id.
+//! * `i`, `tid` - The current system-wide unique thread ID.
 //! * `n` - A platform-specific newline.
 //! * `t`, `target` - The target of the log message.
 //! * `T`, `thread` - The name of the current thread.
-//! * `I`, `thread_id` - The ID of the current thread.
+//! * `I`, `thread_id` - The pthread ID of the current thread.
 //! * `X`, `mdc` - A value from the [MDC][MDC]. The first argument specifies
 //!     the key, and the second argument specifies the default value if the
 //!     key is not present in the MDC. The second argument is optional, and
@@ -452,6 +453,7 @@ impl<'a> From<Piece<'a>> for Chunk {
                 "T" | "thread" => no_args(&formatter.args, parameters, FormattedChunk::Thread),
                 "I" | "thread_id" => no_args(&formatter.args, parameters, FormattedChunk::ThreadId),
                 "P" | "pid" => no_args(&formatter.args, parameters, FormattedChunk::ProcessId),
+                "i" | "tid" => no_args(&formatter.args, parameters, FormattedChunk::SystemThreadId),
                 "t" | "target" => no_args(&formatter.args, parameters, FormattedChunk::Target),
                 "X" | "mdc" => {
                     if formatter.args.len() > 2 {
@@ -542,6 +544,7 @@ enum FormattedChunk {
     Thread,
     ThreadId,
     ProcessId,
+    SystemThreadId,
     Target,
     Newline,
     Align(Vec<Chunk>),
@@ -569,6 +572,9 @@ impl FormattedChunk {
             }
             FormattedChunk::ThreadId => w.write_all(thread_id::get().to_string().as_bytes()),
             FormattedChunk::ProcessId => w.write_all(process::id().to_string().as_bytes()),
+            FormattedChunk::SystemThreadId => {
+                super::TID.with(|tid| w.write_all(tid.to_string().as_bytes()))
+            }
             FormattedChunk::Target => w.write_all(record.target().as_bytes()),
             FormattedChunk::Newline => w.write_all(NEWLINE.as_bytes()),
             FormattedChunk::Align(ref chunks) => {
@@ -784,6 +790,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(buf, process::id().to_string().as_bytes());
+    }
+
+    #[test]
+    #[cfg(feature = "simple_writer")]
+    fn system_thread_id() {
+        let pw = PatternEncoder::new("{i}");
+        let mut buf = vec![];
+
+        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+            .unwrap();
+
+        assert_eq!(buf, gettid::gettid().to_string().as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
Add {i} and {tid} to allow logging in particular the Linux
thread ID as returned by gettid(). This is very useful for
system-wide debugging und monitoring with consistent
thread/task IDs.

Fixes: #231