### PR TITLE
Added documentation for field in FixedWindowRollerBuilder

### DIFF
--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -256,6 +256,8 @@ impl FixedWindowRollerBuilder {
     /// If the file extension of the pattern is `.gz` and the `gzip` Cargo
     /// feature is enabled, the archive files will be gzip-compressed.
     /// If the extension is `.gz` and the `gzip` feature is *not* enabled, an error will be returned.
+    ///
+    /// `count` is the maximum number of archived logs to maintain.
     pub fn build(self, pattern: &str, count: u32) -> anyhow::Result<FixedWindowRoller> {
         if !pattern.contains("{}") {
             bail!("pattern does not contain `{}`");


### PR DESCRIPTION
The count field in FixedWindowRollerBuilder was undocumented. This adds a very short blurb on what it is, as the field name isn't descriptive enough by itself.