### PR TITLE
Hide {} in error message from formatting machinery

### DIFF
--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -258,7 +258,9 @@ impl FixedWindowRollerBuilder {
     /// If the extension is `.gz` and the `gzip` feature is *not* enabled, an error will be returned.
     pub fn build(self, pattern: &str, count: u32) -> anyhow::Result<FixedWindowRoller> {
         if !pattern.contains("{}") {
-            bail!("pattern does not contain `{}`");
+            // Hide {} in this error message from the formatting machinery in bail macro
+            let msg = "pattern does not contain `{}`";
+            bail!(msg);
         }
 
         let compression = match Path::new(pattern).extension() {


### PR DESCRIPTION
I am looking into resolving https://github.com/dtolnay/anyhow/issues/55 and this looks like one of only 2 places on crates.io where "{}" is used intentionally in an error message &mdash; meanwhile there were a couple dozen where it's a bug where they forgot to pass a second argument that was supposed to be interpolated in the message.

If you are open to tweaking this code, I'll land a fix for https://github.com/dtolnay/anyhow/issues/55 to help others catch missed format arguments.