### PR TITLE
Don't require chrono's default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ harness = false
 
 [dependencies]
 arc-swap = "1.2"
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", optional = true, features = ["clock", "std"], default-features = false }
 flate2 = { version = "1.0", optional = true }
 fnv = "1.0"
 humantime = { version = "2.0", optional = true }


### PR DESCRIPTION
This removes an unneccessary dependency on time 0.1