### PR TITLE
Fix link to more examples in src/lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,7 @@
 //! # fn main() {}
 //! ```
 //!
-//! For more examples see the (examples)[https://github.com/estk/log4rs/tree/master/examples].
+//! For more examples see the [examples](https://github.com/estk/log4rs/tree/master/examples).
 //!
 
 #![allow(where_clauses_object_safety, clippy::manual_non_exhaustive)]


### PR DESCRIPTION
I noticed the link to more examples in src/lib.rs is broken: the Markdown syntax is wrong for a link. This fixes it.