### PR TITLE
Added roll on launch for rolling file appenders

### DIFF
--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -315,7 +315,7 @@ fn startup_roll(appender: &RollingFileAppender) -> anyhow::Result<()> {
     let len = {
         let writer = match appender.get_writer(&mut writer) {
             Ok(w) => w,
-            Err(why) => return Err(anyhow::anyhow!("Something went wrong: {}", why.kind())),
+            Err(_) => return Err(anyhow::anyhow!("Could not roll over log file on startup.")),
         };
         writer.flush()?;
         writer.len

--- a/src/append/rolling_file/policy/compound/mod.rs
+++ b/src/append/rolling_file/policy/compound/mod.rs
@@ -7,6 +7,7 @@ use serde::{self, de};
 use serde_value::Value;
 #[cfg(feature = "config_parsing")]
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use crate::append::rolling_file::{policy::Policy, LogFile};
 #[cfg(feature = "config_parsing")]
@@ -107,8 +108,8 @@ impl Policy for CompoundPolicy {
         Ok(())
     }
 
-    fn startup(&self, log: &mut LogFile) -> anyhow::Result<()> {
-        self.roller.roll(log.path())?;
+    fn startup(&self, path: &Path) -> anyhow::Result<()> {
+        self.roller.roll(path)?;
         Ok(())
     }
 }

--- a/src/append/rolling_file/policy/compound/mod.rs
+++ b/src/append/rolling_file/policy/compound/mod.rs
@@ -56,9 +56,9 @@ impl<'de> serde::Deserialize<'de> for Trigger {
 
 #[cfg(feature = "config_parsing")]
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-struct Roller {
-    kind: String,
-    config: Value,
+pub(in crate::append::rolling_file) struct Roller {
+    pub(in crate::append::rolling_file) kind: String,
+    pub(in crate::append::rolling_file) config: Value,
 }
 
 #[cfg(feature = "config_parsing")]

--- a/src/append/rolling_file/policy/compound/mod.rs
+++ b/src/append/rolling_file/policy/compound/mod.rs
@@ -8,15 +8,14 @@ use serde_value::Value;
 #[cfg(feature = "config_parsing")]
 use std::collections::BTreeMap;
 
-use crate::append::rolling_file::{
-    policy::{compound::roll::Roll, Policy},
-    LogFile,
-};
+use crate::append::rolling_file::{policy::Policy, LogFile};
 #[cfg(feature = "config_parsing")]
 use crate::config::{Deserialize, Deserializers};
 
 pub mod roll;
 pub mod trigger;
+
+pub use roll::Roll;
 
 /// Configuration for the compound policy.
 #[cfg(feature = "config_parsing")]
@@ -56,9 +55,9 @@ impl<'de> serde::Deserialize<'de> for Trigger {
 
 #[cfg(feature = "config_parsing")]
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
-pub(in crate::append::rolling_file) struct Roller {
-    pub(in crate::append::rolling_file) kind: String,
-    pub(in crate::append::rolling_file) config: Value,
+struct Roller {
+    kind: String,
+    config: Value,
 }
 
 #[cfg(feature = "config_parsing")]
@@ -105,6 +104,11 @@ impl Policy for CompoundPolicy {
             log.roll();
             self.roller.roll(log.path())?;
         }
+        Ok(())
+    }
+
+    fn startup(&self, log: &mut LogFile) -> anyhow::Result<()> {
+        self.roller.roll(log.path())?;
         Ok(())
     }
 }

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -332,7 +332,7 @@ impl Deserialize for FixedWindowRollerDeserializer {
 }
 
 #[cfg(test)]
-mod test {
+pub(crate) mod test {
     use std::{
         fs::File,
         io::{Read, Write},
@@ -342,7 +342,7 @@ mod test {
     use crate::append::rolling_file::policy::compound::roll::Roll;
 
     #[cfg(feature = "background_rotation")]
-    fn wait_for_roller(roller: &FixedWindowRoller) {
+    pub(crate) fn wait_for_roller(roller: &FixedWindowRoller) {
         std::thread::sleep(std::time::Duration::from_millis(100));
         let _lock = roller.cond_pair.0.lock();
     }

--- a/src/append/rolling_file/policy/mod.rs
+++ b/src/append/rolling_file/policy/mod.rs
@@ -16,6 +16,13 @@ pub trait Policy: Sync + Send + 'static + fmt::Debug {
     /// This method is called after each log event. It is provided a reference
     /// to the current log file.
     fn process(&self, log: &mut LogFile) -> anyhow::Result<()>;
+
+    /// The function that gets called when the policy is built aka. when
+    /// the logger gets initialized.
+    fn startup(&self, _log: &mut LogFile) -> anyhow::Result<()> {
+        // Default implementation here for backwards compatibility reasons
+        Ok(())
+    }
 }
 
 #[cfg(feature = "config_parsing")]

--- a/src/append/rolling_file/policy/mod.rs
+++ b/src/append/rolling_file/policy/mod.rs
@@ -1,5 +1,6 @@
 //! Policies.
 use std::fmt;
+use std::path::Path;
 
 use crate::append::rolling_file::LogFile;
 
@@ -19,8 +20,12 @@ pub trait Policy: Sync + Send + 'static + fmt::Debug {
 
     /// The function that gets called when the policy is built aka. when
     /// the logger gets initialized.
-    fn startup(&self, _log: &mut LogFile) -> anyhow::Result<()> {
-        // Default implementation here for backwards compatibility reasons
+    ///
+    /// `path` is the path to the current logfile.
+    /// This log file is opened by the builder and therefore not writable.
+    ///
+    /// Default implementation here for backwards compatibility reasons
+    fn startup(&self, _path: &Path) -> anyhow::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
Adds an option to roll the log files on startup.

It is a different approach to @OvermindDL1's #219.

---

## Usage Examples
### with yaml:
```yaml
refresh_rate: 30 seconds

appenders:
  stderr:
    kind: console
    target: stderr
  logfile:
    kind: rolling_file
    path: logs/log-0.log
    encoder:
      pattern: "{l} - {m}\n"
    policy:
      kind: compound
      trigger:
        kind: size
        limit: 10 mb
      roller: &roll
        kind: fixed_window
        pattern: "logs/log-{}.log"
        base: 1
        count: 5
    roll_on_startup: true

root:
  level: info
  appenders:
    - stdout
    - logfile
```

### programmatically
```rust
use log::{debug, error, info, trace, warn, LevelFilter, SetLoggerError};
use log4rs::append::rolling_file::{
    policy::compound::{
        roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger, CompoundPolicy,
    },
    RollingFileAppender,
};
use log4rs::{
    append::console::{ConsoleAppender, Target},
    config::{Appender, Config, Root},
    encode::pattern::PatternEncoder,
    filter::threshold::ThresholdFilter,
};

fn main() -> Result<(), SetLoggerError> {
    let level = log::LevelFilter::Info;
    let file_path = "logs/latest.log";

    let stderr = ConsoleAppender::builder().target(Target::Stderr).build();

    let logfile = RollingFileAppender::builder()
        // Pattern: https://docs.rs/log4rs/*/log4rs/encode/pattern/index.html
        .encoder(Box::new(PatternEncoder::new("{l} - {m}\n")))
        .roll_on_startup(true)
        .build(
            file_path,
            Box::new(CompoundPolicy::new(
                Box::new(SizeTrigger::new(10_000_000)),
                Box::new(
                    FixedWindowRoller::builder()
                        .build("logs/log-{}.log", 5)
                        .unwrap(),
                ),
            )),
        )
        .unwrap();

    let config = Config::builder()
        .appender(Appender::builder().build("logfile", Box::new(logfile)))
        .appender(
            Appender::builder()
                .filter(Box::new(ThresholdFilter::new(level)))
                .build("stderr", Box::new(stderr)),
        )
        .build(
            Root::builder()
                .appender("logfile")
                .appender("stderr")
                .build(LevelFilter::Trace),
        )
        .unwrap();

    let _handle = log4rs::init_config(config)?;

    error!("Goes to stderr and file");
    warn!("Goes to stderr and file");
    info!("Goes to stderr and file");
    debug!("Goes to file only");
    trace!("Goes to file only");

    Ok(())
}
```