### PR TITLE
Make `parking_lot` feature fully optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,16 @@ keywords = ["log", "logger", "logging", "log4"]
 edition = '2018'
 
 [features]
-default = ["all_components", "config_parsing", "yaml_format"]
+default = ["all_components", "config_parsing", "yaml_format", "parking_lot"]
 
 config_parsing = ["humantime", "serde", "serde-value", "typemap", "log/serde"]
 yaml_format = ["serde_yaml"]
 json_format = ["serde_json"]
 toml_format = ["toml"]
 
-console_appender = ["console_writer", "simple_writer", "pattern_encoder"]
-file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
-rolling_file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
+console_appender = ["console_writer", "simple_writer"]
+file_appender = ["simple_writer", "pattern_encoder"]
+rolling_file_appender = ["simple_writer", "pattern_encoder"]
 compound_policy = []
 delete_roller = []
 fixed_window_roller = []

--- a/src/append/file.rs
+++ b/src/append/file.rs
@@ -4,7 +4,7 @@
 
 use derivative::Derivative;
 use log::Record;
-use parking_lot::Mutex;
+use crate::sync::Mutex;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
@@ -43,7 +43,7 @@ pub struct FileAppender {
 
 impl Append for FileAppender {
     fn append(&self, record: &Record) -> anyhow::Result<()> {
-        let mut file = self.file.lock();
+        let mut file = self.file.lock()?;
         self.encoder.encode(&mut *file, record)?;
         file.flush()?;
         Ok(())

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -18,7 +18,7 @@
 
 use derivative::Derivative;
 use log::Record;
-use parking_lot::Mutex;
+use crate::sync::Mutex;
 use std::{
     fs::{self, File, OpenOptions},
     io::{self, BufWriter, Write},
@@ -165,7 +165,7 @@ pub struct RollingFileAppender {
 impl Append for RollingFileAppender {
     fn append(&self, record: &Record) -> anyhow::Result<()> {
         // TODO(eas): Perhaps this is better as a concurrent queue?
-        let mut writer = self.writer.lock();
+        let mut writer = self.writer.lock()?;
 
         let len = {
             let writer = self.get_writer(&mut writer)?;
@@ -273,7 +273,8 @@ impl RollingFileAppenderBuilder {
         }
 
         // open the log file immediately
-        appender.get_writer(&mut appender.writer.lock())?;
+        // unwrap guaranteed to succeed since this is the first time the mutex is being locked
+        appender.get_writer(&mut appender.writer.lock().unwrap())?;
 
         Ok(appender)
     }


### PR DESCRIPTION
Currently, if you use the `file_appender` or `rolling_file_appender` features then this pulls `parking_lot` into the dependency tree. This PR would keep `parking_lot` as a default, but allow users to use those features without parking lot. The implementation details of this are sealed from the public API, so there are no breaking changes.