### PR TITLE
Add support for global MDC argument.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ flate2 = { version = "1.0", optional = true }
 fnv = "1.0"
 humantime = { version = "2.0", optional = true }
 log = { version = "0.4.0", features = ["std"] }
-log-mdc = { version = "0.1", optional = true }
+log-mdc = { version = "0.2", git = "https://github.com/gaoqiangz/rust-log-mdc.git", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
 thread-id = { version = "4", optional = true }


### PR DESCRIPTION
Global value for all threads output.
Pattern argument:
`XG`, `gmdc`
* `{XG(node_id)}` - `node-win-554488715635`
* `{XG(nonexistent_key)(no mapping)}` - `no mapping`