### PR TITLE
fix:Update typemap to use orphanage-rs impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = '2018'
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]
 
-config_parsing = ["humantime", "serde", "serde-value", "typemap", "log/serde"]
+config_parsing = ["humantime", "serde", "serde-value", "typemap-ors", "log/serde"]
 yaml_format = ["serde_yaml"]
 json_format = ["serde_json"]
 toml_format = ["toml"]
@@ -62,7 +62,7 @@ log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
 thread-id = { version = "4", optional = true }
-typemap = { version = "0.3", optional = true }
+typemap-ors = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.8.4", optional = true }
 toml = { version = "0.5", optional = true }

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -100,7 +100,7 @@ use log::LevelFilter;
 use serde::de::{self, Deserialize as SerdeDeserialize, DeserializeOwned};
 use serde_value::Value;
 use thiserror::Error;
-use typemap::{Key, ShareCloneMap};
+use typemap_ors::{Key, ShareCloneMap};
 
 use crate::{append::AppenderConfig, config};
 


### PR DESCRIPTION
Moves the typemap to point at the orphanage-rs implementation so we can address CVEs
Signed-off-by: Anton Whalley <anton@venshare.com>
