### PR TITLE
Daily file Appender

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ toml_format = ["toml"]
 
 console_appender = ["console_writer", "simple_writer", "pattern_encoder"]
 file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
+daily_file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
 rolling_file_appender = ["parking_lot", "simple_writer", "pattern_encoder"]
 compound_policy = []
 delete_roller = []
@@ -35,6 +36,7 @@ background_rotation = []
 all_components = [
     "console_appender",
     "file_appender",
+    "daily_file_appender",
     "rolling_file_appender",
     "compound_policy",
     "delete_roller",

--- a/src/append/daily_file.rs
+++ b/src/append/daily_file.rs
@@ -75,7 +75,8 @@ impl Append for DailyFileAppender {
                 .append(true)
                 .create(true)
                 .open(&filename)?;
-            file.file_handle = SimpleWriter(BufWriter::with_capacity(1024, new_file))
+            file.file_handle = SimpleWriter(BufWriter::with_capacity(1024, new_file));
+            file.name = filename;
         }
 
         self.encoder.encode(&mut file.file_handle, record)?;

--- a/src/append/daily_file.rs
+++ b/src/append/daily_file.rs
@@ -60,7 +60,16 @@ impl Append for DailyFileAppender {
         let today_str = today.format("%Y-%m-%d").to_string();
         let filename = self.pattern.replace("{}", &today_str);
         if file.name != filename {
-            // Reopen file
+            let mut path_buf = PathBuf::new();
+            path_buf.push(filename.clone());
+
+            let path = super::env_util::expand_env_vars(path_buf);
+
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            // open new file
             let new_file = OpenOptions::new()
                 .write(true)
                 .append(true)

--- a/src/append/daily_file.rs
+++ b/src/append/daily_file.rs
@@ -1,0 +1,192 @@
+//! The daily file appender.
+//!
+//! Requires the `daily_file_appender` feature.
+
+use chrono::{Local, Date};
+use derivative::Derivative;
+use log::Record;
+use parking_lot::Mutex;
+use std::{
+    fs::{self, File, OpenOptions},
+    io::{self, BufWriter, Write},
+    path::{PathBuf},
+};
+
+#[cfg(feature = "config_parsing")]
+use crate::config::{Deserialize, Deserializers};
+#[cfg(feature = "config_parsing")]
+use crate::encode::EncoderConfig;
+
+use crate::{
+    append::Append,
+    encode::{pattern::PatternEncoder, writer::simple::SimpleWriter, Encode},
+};
+
+/// The daily_file appender's configuration.
+#[cfg(feature = "config_parsing")]
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Default, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DailyFileAppenderConfig {
+    pattern: String,
+    encoder: Option<EncoderConfig>,
+    append: Option<bool>,
+}
+
+/// Wrap file_name with it's name
+pub struct FileWithName {
+    /// file handle
+    pub file_handle: SimpleWriter<BufWriter<File>>,
+    /// file name
+    pub name: String,
+}
+
+/// An appender which logs to a file.
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct DailyFileAppender {
+    pattern: String,
+    path: PathBuf,
+    #[derivative(Debug = "ignore")]
+    file: Mutex<FileWithName>,
+    encoder: Box<dyn Encode>,
+}
+
+impl Append for DailyFileAppender {
+    fn append(&self, record: &Record) -> anyhow::Result<()> {
+        let mut file = self.file.lock();
+
+        // check if day changes
+        let today: Date<Local> = Local::today();
+        let today_str = today.format("%Y-%m-%d").to_string();
+        let filename = self.pattern.replace("{}", &today_str);
+        if file.name != filename {
+            // Reopen file
+            let new_file = OpenOptions::new()
+                .write(true)
+                .append(true)
+                .create(true)
+                .open(&filename)?;
+            file.file_handle = SimpleWriter(BufWriter::with_capacity(1024, new_file))
+        }
+
+        self.encoder.encode(&mut file.file_handle, record)?;
+        file.file_handle.flush()?;
+        Ok(())
+    }
+
+    fn flush(&self) {}
+}
+
+impl DailyFileAppender {
+    /// Creates a new `DailyFileAppender` builder.
+    pub fn builder() -> DailyFileAppenderBuilder {
+        DailyFileAppenderBuilder {
+            encoder: None,
+        }
+    }
+}
+
+/// A builder for `DailyFileAppender`s.
+pub struct DailyFileAppenderBuilder {
+    encoder: Option<Box<dyn Encode>>,
+}
+
+impl DailyFileAppenderBuilder {
+    /// Sets the output encoder for the `DilyFileAppender`.
+    pub fn encoder(mut self, encoder: Box<dyn Encode>) -> DailyFileAppenderBuilder {
+        self.encoder = Some(encoder);
+        self
+    }
+
+    /// Consumes the `DailyFileAppenderBuilder`, producing a `DailyFileAppender`.
+    /// The path argument can contain environment variables of the form $ENV{name_here},
+    /// where 'name_here' will be the name of the environment variable that
+    /// will be resolved. Note that if the variable fails to resolve,
+    /// $ENV{name_here} will NOT be replaced in the path.
+    pub fn build(self, pattern: &str) -> io::Result<DailyFileAppender> {
+        let today: Date<Local> = Local::today();
+        let today_str = today.format("%Y-%m-%d").to_string();
+        let filename = pattern.replace("{}", &today_str);
+
+        let mut path_buf = PathBuf::new();
+        path_buf.push(filename.clone());
+
+        let path = super::env_util::expand_env_vars(path_buf);
+
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let file = OpenOptions::new()
+            .write(true)
+            .append(true)
+            .create(true)
+            .open(&filename)?;
+
+        Ok(DailyFileAppender {
+            pattern: String::from(pattern),
+            path: path,
+            file: Mutex::new(FileWithName {
+                file_handle: SimpleWriter(BufWriter::with_capacity(1024, file)),
+                name: filename,
+            }),
+            encoder: self
+                .encoder
+                .unwrap_or_else(|| Box::new(PatternEncoder::default())),
+        })
+    }
+}
+
+/// A deserializer for the `DailyFileAppender`.
+///
+/// # Configuration
+///
+/// ```yaml
+/// kind: daily_file
+///
+/// # The path of the log file. Required.
+/// # {} will be replaced by date YYYY.MM.DD
+/// pattern: log/foo_{}_.log
+///
+/// # The encoder to use to format output. Defaults to `kind: pattern`.
+/// encoder:
+///   kind: pattern
+/// ```
+#[cfg(feature = "config_parsing")]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]
+pub struct DailyFileAppenderDeserializer;
+
+#[cfg(feature = "config_parsing")]
+impl Deserialize for DailyFileAppenderDeserializer {
+    type Trait = dyn Append;
+
+    type Config = DailyFileAppenderConfig;
+
+    fn deserialize(
+        &self,
+        config: DailyFileAppenderConfig,
+        deserializers: &Deserializers,
+    ) -> anyhow::Result<Box<Self::Trait>> {
+        let mut appender = DailyFileAppender::builder();
+        if let Some(encoder) = config.encoder {
+            appender = appender.encoder(deserializers.deserialize(&encoder.kind, encoder.config)?);
+        }
+        Ok(Box::new(appender.build(&config.pattern)?))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn create_directories() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let mut path_buf = PathBuf::new();
+        path_buf.push(tempdir);
+        path_buf.push("foo_{}_.log");
+
+        DailyFileAppender::builder()
+            .build(&path_buf.as_path().to_str().unwrap())
+            .unwrap();
+    }
+}

--- a/src/append/mod.rs
+++ b/src/append/mod.rs
@@ -18,6 +18,8 @@ use crate::filter::FilterConfig;
 pub mod console;
 #[cfg(feature = "file_appender")]
 pub mod file;
+#[cfg(feature = "daily_file_appender")]
+pub mod daily_file;
 #[cfg(feature = "rolling_file_appender")]
 pub mod rolling_file;
 

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -186,6 +186,9 @@ impl Default for Deserializers {
         #[cfg(feature = "file_appender")]
         d.insert("file", append::file::FileAppenderDeserializer);
 
+        #[cfg(feature = "daily_file_appender")]
+        d.insert("daily_file", append::daily_file::DailyFileAppenderDeserializer);
+
         #[cfg(feature = "rolling_file_appender")]
         d.insert(
             "rolling_file",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! Implementations:
 //!   - [console](append/console/struct.ConsoleAppenderDeserializer.html#configuration): requires the `console_appender` feature.
 //!   - [file](append/file/struct.FileAppenderDeserializer.html#configuration): requires the `file_appender` feature.
+//!   - [daily_file](append/daily_file/struct.DailyFileAppenderDeserializer.html#configuration): requires the `daily_file_appender` feature.
 //!   - [rolling_file](append/rolling_file/struct.RollingFileAppenderDeserializer.html#configuration): requires the `rolling_file_appender` feature and can be configured with the `compound_policy`.
 //!     - [compound](append/rolling_file/policy/compound/struct.CompoundPolicyDeserializer.html#configuration): requires the `compound_policy` feature
 //!       - Rollers


### PR DESCRIPTION
Adds a daily_file appender, similar to file appender.
It would create a new file each day.

sample config :

appenders:
  daily_file:
    kind: daily_file
    pattern: "log/log_{}_.log"

{} will be replaced by YYYY-MM-DD with today's date (Local datetime).