### PR TITLE
chore: update Rust version for latest log crate compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_versions: ["stable", "1.57"]
+        rust_versions: ["stable", "1.60"]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout the source code
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_versions: ["stable", "1.57"]
+        rust_versions: ["stable", "1.60"]
     steps:
       - name: Checkout the source code
         uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ chrono = { version = "0.4", optional = true }
 flate2 = { version = "1.0", optional = true }
 fnv = "1.0"
 humantime = { version = "2.0", optional = true }
-log = { version = "=0.4.17", features = ["std"] }
+log = { version = "0.4.20", features = ["std"] }
 log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "log4rs"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Steven Fackler <sfackler@gmail.com>", "Evan Simmons <esims89@gmail.com>"]
 description = "A highly configurable multi-output logging implementation for the `log` facade"
 license = "MIT/Apache-2.0"
@@ -8,7 +8,7 @@ repository = "https://github.com/estk/log4rs"
 readme = "README.md"
 keywords = ["log", "logger", "logging", "log4"]
 edition = "2018"
-rust = "1.57"
+rust = "1.60"
 
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fn main() {
 
 ## Rust Version Requirements
 
-1.57
+1.60
 
 ## Building for Dev
 


### PR DESCRIPTION
Upgrade minimum rust version to 1.60 to allow usage of the latest log crate. 