### PR TITLE
chore(deps): Bump deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_versions: ["stable", "1.60"]
+        rust_versions: ["stable", "1.67"]
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout the source code
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_versions: ["stable", "1.60"]
+        rust_versions: ["stable", "1.67"]
     steps:
       - name: Checkout the source code
         uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/estk/log4rs"
 readme = "README.md"
 keywords = ["log", "logger", "logging", "log4"]
 edition = "2018"
-rust = "1.60"
+rust-version = "1.67"
 
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]
@@ -53,11 +53,11 @@ name = "rotation"
 harness = false
 
 [dependencies]
-arc-swap = "1.2"
+arc-swap = "1.6"
 chrono = { version = "0.4", optional = true }
 flate2 = { version = "1.0", optional = true }
 fnv = "1.0"
-humantime = { version = "2.0", optional = true }
+humantime = { version = "2.1", optional = true }
 log = { version = "0.4.20", features = ["std"] }
 log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
@@ -65,12 +65,12 @@ serde-value = { version = "0.7", optional = true }
 thread-id = { version = "4", optional = true }
 typemap-ors = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.8.4", optional = true }
-toml = { version = "0.5", optional = true }
+serde_yaml = { version = "0.9", optional = true }
+toml = { version = "0.8", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 thiserror = "1.0.15"
 anyhow = "1.0.28"
-derivative = "2.1.1"
+derivative = "2.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon"] }
@@ -81,8 +81,8 @@ libc = { version = "0.2", optional = true }
 [dev-dependencies]
 lazy_static = "1.4"
 streaming-stats = "0.2.3"
-humantime = "2.0"
-tempfile = "3.1.0"
+humantime = "2.1"
+tempfile = "3.8"
 
 [[example]]
 name = "json_logger"


### PR DESCRIPTION
Glad to see the PR moving again.
This PR will bump a series of dependencies.

 Bump `arc-swap` from 1.2 to 1.6.
 Bump `humantime` from 2.0 to 2.1.
 Bump `serde_yaml` from 0.8.4 to 0.9.
 Bump `toml` from 0.5 to 0.8.
 Bump `parking_lot` from 2.0 to 2.1.
 Bump `derivative` from 2.1.1 to 2.2.
 Bump `tempfile` from 3.1.0 to 3.8.

