### PR TITLE
chore: update deprecated merge_imports && fmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,1 @@
-merge_imports = true
+imports_granularity="Crate"

--- a/benches/rotation.rs
+++ b/benches/rotation.rs
@@ -1,5 +1,7 @@
-use std::thread;
-use std::time::{Duration, Instant};
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 use lazy_static::lazy_static;
 use tempfile::{tempdir, TempDir};

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -12,8 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::append::env_util::expand_env_vars;
-use crate::append::rolling_file::policy::compound::roll::Roll;
+use crate::append::{env_util::expand_env_vars, rolling_file::policy::compound::roll::Roll};
 #[cfg(feature = "config_parsing")]
 use crate::config::{Deserialize, Deserializers};
 


### PR DESCRIPTION
# What does this PR do

1. `merge_imports` is deprecated now, update it to `imports_granularity`.
2. Format code
