### PR TITLE
Fix quickstart log4rs.yaml sample

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -19,6 +19,7 @@ indent_size = false
 
 [*.md]
 trim_trailing_whitespace = false
+indent_size = 2
 
 [*.{yml,yaml}]
 indent_size = 2

--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ log4rs.yaml:
 ```yaml
 refresh_rate: 30 seconds
 appenders:
-    stdout:
-        kind: console
-    requests:
-        kind: file
-        path: "log/requests.log"
-        encoder:
-            pattern: "{d} - {m}{n}"
-    root:
-        level: warn
-        appenders:
-            - stdout
-    loggers:
-        app::backend::db:
-            level: info
-    app::requests:
-        level: info
-        appenders:
-            - requests
-        additive: false
+  stdout:
+    kind: console
+  requests:
+    kind: file
+    path: "log/requests.log"
+    encoder:
+      pattern: "{d} - {m}{n}"
+root:
+  level: warn
+  appenders:
+    - stdout
+loggers:
+  app::backend::db:
+    level: info
+  app::requests:
+    level: info
+    appenders:
+      - requests
+    additive: false
 ```
 
 lib.rs:

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -457,6 +457,8 @@ fn logger_additive_default() -> bool {
 #[cfg(test)]
 #[allow(unused_imports)]
 mod test {
+    use std::fs;
+
     use super::*;
 
     #[test]
@@ -499,5 +501,24 @@ loggers:
     #[cfg(feature = "yaml_format")]
     fn empty() {
         ::serde_yaml::from_str::<RawConfig>("{}").unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "yaml_format")]
+    fn readme_sample_file_is_ok() {
+        let readme = fs::read_to_string("./README.md").expect("README file exists");
+        let sample_file = &readme[readme
+            .find("log4rs.yaml:")
+            .expect("Sample file exists and is called log4rs.yaml")..];
+        let config_start_string = "\n```yaml\n";
+        let config_end_string = "\n```\n";
+
+        let config_start =
+            sample_file.find(config_start_string).unwrap() + config_start_string.len();
+        let config_end = sample_file.find(config_end_string).unwrap();
+        let config_str = sample_file[config_start..config_end].trim();
+
+        let config = ::serde_yaml::from_str::<RawConfig>(config_str);
+        assert!(config.is_ok())
     }
 }

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -504,8 +504,10 @@ loggers:
     }
 
     #[cfg(windows)]
+    #[allow(dead_code)]
     const LINE_ENDING: &'static str = "\r\n";
     #[cfg(not(windows))]
+    #[allow(dead_code)]
     const LINE_ENDING: &'static str = "\n";
 
     #[test]
@@ -520,7 +522,6 @@ loggers:
         let config_start =
             sample_file.find(&config_start_string).unwrap() + config_start_string.len();
         let config_end = sample_file.find(&config_end_string).unwrap();
-        
         let config_str = sample_file[config_start..config_end].trim();
 
         let config = ::serde_yaml::from_str::<RawConfig>(config_str);

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -503,6 +503,11 @@ loggers:
         ::serde_yaml::from_str::<RawConfig>("{}").unwrap();
     }
 
+    #[cfg(windows)]
+    const LINE_ENDING: &'static str = "\r\n";
+    #[cfg(not(windows))]
+    const LINE_ENDING: &'static str = "\n";
+
     #[test]
     #[cfg(feature = "yaml_format")]
     fn readme_sample_file_is_ok() {
@@ -510,12 +515,12 @@ loggers:
         let sample_file = &readme[readme
             .find("log4rs.yaml:")
             .expect("Sample file exists and is called log4rs.yaml")..];
-        let config_start_string = "\n```yaml\n";
-        let config_end_string = "\n```\n";
-
+        let config_start_string = format!("{}```yaml{}", LINE_ENDING, LINE_ENDING);
+        let config_end_string = format!("{}```{}", LINE_ENDING, LINE_ENDING);
         let config_start =
-            sample_file.find(config_start_string).unwrap() + config_start_string.len();
-        let config_end = sample_file.find(config_end_string).unwrap();
+            sample_file.find(&config_start_string).unwrap() + config_start_string.len();
+        let config_end = sample_file.find(&config_end_string).unwrap();
+        
         let config_str = sample_file[config_start..config_end].trim();
 
         let config = ::serde_yaml::from_str::<RawConfig>(config_str);


### PR DESCRIPTION
Fails parsing the current config. Seems to have been changed accidentally as it doesn't make sense that root and logger are defined within appenders.