### PR TITLE
test: size trigger, cleanup control color, MSRV bump for toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_versions: ["stable", "1.69"]
+        rust_versions: ["stable", "1.70"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the source code
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_versions: ["stable", "1.69"]
+        rust_versions: ["stable", "1.70"]
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/estk/log4rs"
 readme = "README.md"
 keywords = ["log", "logger", "logging", "log4"]
 edition = "2018"
-rust-version = "1.69"
+rust-version = "1.70"
 
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]
@@ -88,6 +88,7 @@ streaming-stats = "0.2.3"
 humantime = "2.1"
 tempfile = "3.8"
 mock_instant = "0.3"
+serde_test = "1.0.176"
 
 [[example]]
 name = "json_logger"
@@ -107,4 +108,8 @@ required-features = ["file_appender", "rolling_file_appender", "size_trigger"]
 
 [[example]]
 name = "multi_logger_config"
+required-features = ["yaml_format", "config_parsing"]
+
+[[example]]
+name = "color_control"
 required-features = ["yaml_format", "config_parsing"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/log4rs.svg)](https://crates.io/crates/log4rs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/clippy.svg)](#license)
 ![CI](https://github.com/estk/log4rs/workflows/CI/badge.svg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.69+-green.svg)](https://github.com/estk/log4rs#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.70+-green.svg)](https://github.com/estk/log4rs#rust-version-requirements)
 
 log4rs is a highly configurable logging framework modeled after Java's Logback
 and log4j libraries.
@@ -71,7 +71,7 @@ fn main() {
 
 ## Rust Version Requirements
 
-1.69
+1.70
 
 ## Building for Dev
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -174,7 +174,7 @@ other components, the default (and only supported) policy is `kind: compound`.
 The _trigger_ field is used to dictate when the log file should be rolled. It
 supports two types: `size`, and `time`.
 
-For `size`, it require a _limit_ field. The _limit_ field is a string which defines the maximum file size
+For `size`, it requires a _limit_ field. The _limit_ field is a string which defines the maximum file size
 prior to a rolling of the file. The limit field requires one of the following
 units in bytes, case does not matter:
 

--- a/examples/color_control.rs
+++ b/examples/color_control.rs
@@ -20,6 +20,12 @@ fn main() {
         Ok(cli_color) => cli_color,
         Err(_) => "0".to_string(),
     };
-    info!("NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}", no_color, clicolor_force, cli_color);
-    error!("NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}", no_color, clicolor_force, cli_color);
+    info!(
+        "NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}",
+        no_color, clicolor_force, cli_color
+    );
+    error!(
+        "NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}",
+        no_color, clicolor_force, cli_color
+    );
 }

--- a/examples/color_control.rs
+++ b/examples/color_control.rs
@@ -1,0 +1,25 @@
+use log::{error, info};
+use log4rs;
+use serde_yaml;
+use std::env;
+
+fn main() {
+    let config_str = include_str!("sample_config.yml");
+    let config = serde_yaml::from_str(config_str).unwrap();
+    log4rs::init_raw_config(config).unwrap();
+
+    let no_color = match env::var("NO_COLOR") {
+        Ok(no_color) => no_color,
+        Err(_) => "0".to_string(),
+    };
+    let clicolor_force = match env::var("CLICOLOR_FORCE") {
+        Ok(clicolor_force) => clicolor_force,
+        Err(_) => "0".to_string(),
+    };
+    let cli_color = match env::var("CLICOLOR") {
+        Ok(cli_color) => cli_color,
+        Err(_) => "0".to_string(),
+    };
+    info!("NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}", no_color, clicolor_force, cli_color);
+    error!("NO_COLOR: {}, CLICOLOR_FORCE: {}, CLICOLOR: {}", no_color, clicolor_force, cli_color);
+}

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -157,8 +157,11 @@ impl Deserialize for SizeTriggerDeserializer {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[cfg(feature = "config_parsing")]
     use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
 
+    #[cfg(feature = "config_parsing")]
     static BYTE_MULTIPLIER: u64 = 1024;
 
     #[test]

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -297,6 +297,23 @@ mod test {
             ],
             "invalid value: string \"pb\", expected a valid unit",
         );
+
+        // u64::MAX which will overflow when converted to bytes
+        let size = "18446744073709551615 kb";
+        // Test not an unsigned number
+        assert_de_tokens_error::<SizeTriggerConfig>(
+            &[
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
+                Token::Str("limit"),
+                Token::Str(size),
+                Token::StructEnd,
+            ],
+            "invalid value: string \"18446744073709551615 kb\", expected a byte size",
+        );
+
     }
 
     #[test]

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -283,6 +283,20 @@ mod test {
             ],
             "invalid value: string \"\", expected a number",
         );
+
+        // Test not an unsigned number
+        assert_de_tokens_error::<SizeTriggerConfig>(
+            &[
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
+                Token::Str("limit"),
+                Token::Str("1024 pb"),
+                Token::StructEnd,
+            ],
+            "invalid value: string \"pb\", expected a valid unit",
+        );
     }
 
     #[test]

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -313,7 +313,6 @@ mod test {
             ],
             "invalid value: string \"18446744073709551615 kb\", expected a byte size",
         );
-
     }
 
     #[test]

--- a/src/append/rolling_file/policy/compound/trigger/size.rs
+++ b/src/append/rolling_file/policy/compound/trigger/size.rs
@@ -197,39 +197,52 @@ mod test {
     #[test]
     #[cfg(feature = "config_parsing")]
     fn test_u64_deserialize() {
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER,
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::U64(1024),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
 
     #[test]
     #[cfg(feature = "config_parsing")]
     fn test_i64_deserialize() {
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER,
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::I64(1024),
                 Token::StructEnd,
-                ],
+            ],
         );
 
         assert_de_tokens_error::<SizeTriggerConfig>(
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::I64(-1024),
                 Token::StructEnd,
-                ],
+            ],
             "invalid value: integer `-1024`, expected a non-negative number",
         );
     }
@@ -238,25 +251,33 @@ mod test {
     #[cfg(feature = "config_parsing")]
     fn test_str_deserialize() {
         // Test no unit (aka value in Bytes)
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER,
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1024"),
                 Token::StructEnd,
-                ],
+            ],
         );
 
         // Test not an unsigned number
         assert_de_tokens_error::<SizeTriggerConfig>(
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("-1024"),
                 Token::StructEnd,
-                ],
+            ],
             "invalid value: string \"\", expected a number",
         );
     }
@@ -264,70 +285,92 @@ mod test {
     #[test]
     #[cfg(feature = "config_parsing")]
     fn byte_deserialize() {
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER,
+        };
 
         // Test spacing & b vs B
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1024b"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1024 B"),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
 
     #[test]
     #[cfg(feature = "config_parsing")]
     fn kilobyte_deserialize() {
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER,
+        };
 
         // Test kb unit
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 kb"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 KB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 kB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 Kb"),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
 
@@ -335,42 +378,56 @@ mod test {
     #[cfg(feature = "config_parsing")]
     fn megabyte_deserialize() {
         // Test mb unit
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER.pow(2) };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER.pow(2),
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 mb"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 MB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 mB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 Mb"),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
 
@@ -378,42 +435,56 @@ mod test {
     #[cfg(feature = "config_parsing")]
     fn gigabyte_deserialize() {
         // Test gb unit
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER.pow(3) };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER.pow(3),
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 gb"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 GB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 gB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 Gb"),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
 
@@ -421,43 +492,56 @@ mod test {
     #[cfg(feature = "config_parsing")]
     fn terabyte_deserialize() {
         // Test tb unit
-        let trigger = SizeTriggerConfig{ limit: BYTE_MULTIPLIER.pow(4) };
+        let trigger = SizeTriggerConfig {
+            limit: BYTE_MULTIPLIER.pow(4),
+        };
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 tb"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 TB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 tB"),
                 Token::StructEnd,
-                ],
+            ],
         );
         assert_de_tokens(
             &trigger,
             &[
-                Token::Struct { name: "SizeTriggerConfig", len: 1 },
+                Token::Struct {
+                    name: "SizeTriggerConfig",
+                    len: 1,
+                },
                 Token::Str("limit"),
                 Token::Str("1 Tb"),
                 Token::StructEnd,
-                ],
+            ],
         );
     }
-
 }

--- a/src/append/rolling_file/policy/compound/trigger/time.rs
+++ b/src/append/rolling_file/policy/compound/trigger/time.rs
@@ -433,11 +433,11 @@ mod test {
     #[cfg(feature = "yaml_format")]
     fn test_serde() {
         let test_error = vec![
-            "abc",   // // str none none
+            "abc",   // str
             "",      // none
             "5 das", // bad unit
-            "-1",    // inegative integar
-            "2.0",   //flaot
+            "-1",    // negative integar
+            "2.0",   // float
         ];
 
         for interval in test_error.iter() {

--- a/tests/color_control.rs
+++ b/tests/color_control.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 fn execute_test(env_key: &str, env_val: &str) {
     let mut child_proc = Command::new("cargo")
-        .args(&["run", "--example", "compile_time_config"])
+        .args(&["run", "--example", "color_control"])
         .env(env_key, env_val)
         .spawn()
         .expect("Cargo command failed to start");
@@ -14,11 +14,39 @@ fn execute_test(env_key: &str, env_val: &str) {
 
 // Maintaining as a single test to avoid blocking calls to the package cache
 #[test]
-fn test_no_color() {
+fn test_single_var() {
     let keys = vec!["NO_COLOR", "CLICOLOR_FORCE", "CLICOLOR"];
 
     for key in keys {
         execute_test(key, "1");
         execute_test(key, "0");
     }
+}
+
+#[test]
+fn test_no_color_vs_force() {
+    let mut child_proc = Command::new("cargo")
+        .args(&["run", "--example", "color_control"])
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR_FORCE", "1")
+        .spawn()
+        .expect("Cargo command failed to start");
+
+    let ecode = child_proc.wait().expect("failed to wait on child");
+
+    assert!(ecode.success());
+}
+
+#[test]
+fn test_no_color_vs_regular() {
+    let mut child_proc = Command::new("cargo")
+        .args(&["run", "--example", "color_control"])
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR", "1")
+        .spawn()
+        .expect("Cargo command failed to start");
+
+    let ecode = child_proc.wait().expect("failed to wait on child");
+
+    assert!(ecode.success());
 }


### PR DESCRIPTION
Utilize serde_test crate for cleaner testing of de serialization, want to update other locations to do the same in the coming weeks.