### PR TITLE
Add support for Key-Value pairs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "log4rs"
 version = "1.3.0"
-authors = ["Steven Fackler <sfackler@gmail.com>", "Evan Simmons <esims89@gmail.com>"]
+authors = [
+    "Steven Fackler <sfackler@gmail.com>",
+    "Evan Simmons <esims89@gmail.com>",
+]
 description = "A highly configurable multi-output logging implementation for the `log` facade"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/estk/log4rs"
@@ -13,7 +16,13 @@ rust-version = "1.69"
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]
 
-config_parsing = ["humantime", "serde", "serde-value", "typemap-ors", "log/serde"]
+config_parsing = [
+    "humantime",
+    "serde",
+    "serde-value",
+    "typemap-ors",
+    "log/serde",
+]
 yaml_format = ["serde_yaml"]
 json_format = ["serde_json"]
 toml_format = ["toml"]
@@ -26,13 +35,21 @@ delete_roller = []
 fixed_window_roller = []
 size_trigger = []
 time_trigger = ["rand"]
-json_encoder = ["serde", "serde_json", "chrono", "log-mdc", "log/serde", "thread-id"]
+json_encoder = [
+    "serde",
+    "serde_json",
+    "chrono",
+    "log-mdc",
+    "log/serde",
+    "thread-id",
+]
 pattern_encoder = ["chrono", "log-mdc", "thread-id"]
 ansi_writer = []
 console_writer = ["ansi_writer", "libc", "winapi"]
 simple_writer = []
 threshold_filter = []
 background_rotation = []
+log_kv = ["log/kv"]
 
 all_components = [
     "console_appender",
@@ -45,7 +62,7 @@ all_components = [
     "time_trigger",
     "json_encoder",
     "pattern_encoder",
-    "threshold_filter"
+    "threshold_filter",
 ]
 
 gzip = ["flate2"]
@@ -56,7 +73,9 @@ harness = false
 
 [dependencies]
 arc-swap = "1.6"
-chrono = { version = "0.4.23", optional = true, features = ["clock"], default-features = false }
+chrono = { version = "0.4.23", optional = true, features = [
+    "clock",
+], default-features = false }
 flate2 = { version = "1.0", optional = true }
 fnv = "1.0"
 humantime = { version = "2.1", optional = true }
@@ -70,14 +89,20 @@ serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 toml = { version = "<0.8.10", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
-rand = { version = "0.8", optional = true}
+rand = { version = "0.8", optional = true }
 thiserror = "1.0.15"
 anyhow = "1.0.28"
 derivative = "2.2"
 once_cell = "1.17.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", optional = true, features = ["handleapi", "minwindef", "processenv", "winbase", "wincon"] }
+winapi = { version = "0.3", optional = true, features = [
+    "handleapi",
+    "minwindef",
+    "processenv",
+    "winbase",
+    "wincon",
+] }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2", optional = true }
@@ -96,7 +121,11 @@ required-features = ["json_encoder", "console_appender"]
 
 [[example]]
 name = "log_to_file"
-required-features = ["console_appender", "file_appender", "rolling_file_appender"]
+required-features = [
+    "console_appender",
+    "file_appender",
+    "rolling_file_appender",
+]
 
 [[example]]
 name = "compile_time_config"

--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -76,6 +76,8 @@ impl JsonEncoder {
             thread: thread.name(),
             thread_id: thread_id::get(),
             mdc: Mdc,
+            #[cfg(feature = "log_kv")]
+            attributes: kv::get_attributes(record.key_values())?,
         };
         message.serialize(&mut serde_json::Serializer::new(&mut *w))?;
         w.write_all(NEWLINE.as_bytes())?;
@@ -106,6 +108,9 @@ struct Message<'a> {
     thread: Option<&'a str>,
     thread_id: usize,
     mdc: Mdc,
+    #[cfg(feature = "log_kv")]
+    #[serde(serialize_with = "kv::ser_map")]
+    attributes: Vec<(String, String)>,
 }
 
 fn ser_display<T, S>(v: &T, s: S) -> Result<S::Ok, S::Error>
@@ -163,6 +168,49 @@ impl Deserialize for JsonEncoderDeserializer {
     }
 }
 
+#[cfg(feature = "log_kv")]
+mod kv {
+    use log::kv::VisitSource;
+
+    pub fn get_attributes(source: &dyn log::kv::Source) -> anyhow::Result<Vec<(String, String)>> {
+        Ok(LogKvVisitor::process(source)?.yield_values())
+    }
+    #[derive(Default)]
+    struct LogKvVisitor {
+        inner: Vec<(String, String)>,
+    }
+
+    impl LogKvVisitor {
+        pub fn process(source: &dyn log::kv::Source) -> anyhow::Result<Self> {
+            let mut s = Self::default();
+            source.visit(&mut s)?;
+            Ok(s)
+        }
+        pub fn yield_values(self) -> Vec<(String, String)> {
+            self.inner
+        }
+    }
+
+    impl<'kvs> VisitSource<'kvs> for LogKvVisitor {
+        fn visit_pair(
+            &mut self,
+            key: log::kv::Key<'kvs>,
+            value: log::kv::Value<'kvs>,
+        ) -> Result<(), log::kv::Error> {
+            self.inner.push((format!("{key}"), format!("{value}")));
+            Ok(())
+        }
+    }
+
+    pub(crate) fn ser_map<S>(v: &[(String, String)], s: S) -> Result<S::Ok, S::Error>
+    where
+        S: super::ser::Serializer,
+    {
+        let iter = v.iter().map(|(k, v)| (k, v));
+        s.collect_map(iter)
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "simple_writer")]
 mod test {
@@ -189,26 +237,35 @@ mod test {
 
         let encoder = JsonEncoder::new();
 
+        let mut record_builder = Record::builder();
+        record_builder
+            .level(level)
+            .target(target)
+            .module_path(Some(module_path))
+            .file(Some(file))
+            .line(Some(line));
+
+        #[cfg(feature = "log_kv")]
+        record_builder.key_values(&[("log_foo", "log_bar")]);
+
         let mut buf = vec![];
         encoder
             .encode_inner(
                 &mut SimpleWriter(&mut buf),
                 time,
-                &Record::builder()
-                    .level(level)
-                    .target(target)
-                    .module_path(Some(module_path))
-                    .file(Some(file))
-                    .line(Some(line))
-                    .args(format_args!("{}", message))
-                    .build(),
+                &record_builder.args(format_args!("{}", message)).build(),
             )
             .unwrap();
+
+        #[cfg(feature = "log_kv")]
+        let expected_attributes = ",\"attributes\":{\"log_foo\":\"log_bar\"}";
+        #[cfg(not(feature = "log_kv"))]
+        let expected_attributes = "";
 
         let expected = format!(
             "{{\"time\":\"{}\",\"level\":\"{}\",\"message\":\"{}\",\"module_path\":\"{}\",\
             \"file\":\"{}\",\"line\":{},\"target\":\"{}\",\
-            \"thread\":\"{}\",\"thread_id\":{},\"mdc\":{{\"foo\":\"bar\"}}}}",
+            \"thread\":\"{}\",\"thread_id\":{},\"mdc\":{{\"foo\":\"bar\"}}{}}}",
             time.to_rfc3339(),
             level,
             message,
@@ -218,6 +275,7 @@ mod test {
             target,
             thread,
             thread_id::get(),
+            expected_attributes
         );
         assert_eq!(expected, String::from_utf8(buf).unwrap().trim());
     }

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -536,6 +536,47 @@ impl<'a> From<Piece<'a>> for Chunk {
                         params: parameters,
                     }
                 }
+                #[cfg(feature = "log_kv")]
+                "K" | "key_value" => {
+                    if formatter.args.len() > 2 {
+                        return Chunk::Error("expected at most two arguments".to_owned());
+                    }
+
+                    let key = match formatter.args.first() {
+                        Some(arg) => {
+                            if let Some(arg) = arg.first() {
+                                match arg {
+                                    Piece::Text(key) => key.to_owned(),
+                                    Piece::Error(ref e) => return Chunk::Error(e.clone()),
+                                    _ => return Chunk::Error("invalid log::kv key".to_owned()),
+                                }
+                            } else {
+                                return Chunk::Error("invalid log::kv key".to_owned());
+                            }
+                        }
+                        None => return Chunk::Error("missing log::kv key".to_owned()),
+                    };
+
+                    let default = match formatter.args.get(1) {
+                        Some(arg) => {
+                            if let Some(arg) = arg.first() {
+                                match arg {
+                                    Piece::Text(key) => key.to_owned(),
+                                    Piece::Error(ref e) => return Chunk::Error(e.clone()),
+                                    _ => return Chunk::Error("invalid log::kv default".to_owned()),
+                                }
+                            } else {
+                                return Chunk::Error("invalid log::kv default".to_owned());
+                            }
+                        }
+                        None => "",
+                    };
+
+                    Chunk::Formatted {
+                        chunk: FormattedChunk::Kv(key.into(), default.into()),
+                        params: parameters,
+                    }
+                }
                 "" => {
                     if formatter.args.len() != 1 {
                         return Chunk::Error("expected exactly one argument".to_owned());
@@ -593,6 +634,8 @@ enum FormattedChunk {
     Debug(Vec<Chunk>),
     Release(Vec<Chunk>),
     Mdc(String, String),
+    #[cfg(feature = "log_kv")]
+    Kv(String, String),
 }
 
 impl FormattedChunk {
@@ -665,6 +708,15 @@ impl FormattedChunk {
             }
             FormattedChunk::Mdc(ref key, ref default) => {
                 log_mdc::get(key, |v| write!(w, "{}", v.unwrap_or(default)))
+            }
+            #[cfg(feature = "log_kv")]
+            FormattedChunk::Kv(ref key, ref default) => {
+                use log::kv::ToKey;
+                if let Some(v) = record.key_values().get(key.to_key()) {
+                    write!(w, "{v}")
+                } else {
+                    write!(w, "{default}")
+                }
             }
         }
     }
@@ -1023,6 +1075,46 @@ mod tests {
     #[cfg(feature = "simple_writer")]
     fn mdc_missing_custom() {
         let pw = PatternEncoder::new("{X(user_id)(missing value)}");
+
+        let mut buf = vec![];
+        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+            .unwrap();
+
+        assert_eq!(buf, b"missing value");
+    }
+
+    #[test]
+    #[cfg(all(feature = "simple_writer", feature = "log_kv"))]
+    fn kv() {
+        let pw = PatternEncoder::new("{K(user_id)}");
+        let mut kv = [("user_id", "kv value")];
+
+        let mut buf = vec![];
+        pw.encode(
+            &mut SimpleWriter(&mut buf),
+            &Record::builder().key_values(&kv).build(),
+        )
+        .unwrap();
+
+        assert_eq!(buf, b"kv value");
+    }
+
+    #[test]
+    #[cfg(all(feature = "simple_writer", feature = "log_kv"))]
+    fn kv_missing_default() {
+        let pw = PatternEncoder::new("{K(user_id)}");
+
+        let mut buf = vec![];
+        pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())
+            .unwrap();
+
+        assert_eq!(buf, b"");
+    }
+
+    #[test]
+    #[cfg(all(feature = "simple_writer", feature = "log_kv"))]
+    fn kv_missing_custom() {
+        let pw = PatternEncoder::new("{K(user_id)(missing value)}");
 
         let mut buf = vec![];
         pw.encode(&mut SimpleWriter(&mut buf), &Record::builder().build())


### PR DESCRIPTION
Hi there,
As discussed in #329, this PR implements support for the `log::kv` structured logging API.
These are some user-facing choices I have made:
- Everything is implemented behind a `log_kv` feature
- Support is added in the two encoders `json` and `pattern`:
    - The `json` message has an `attributes` field which is a serialized map of the record's structured logs
    - The `pattern` encoder has a new `K` or `key_value` formatter which functions exactly like the `mdc` formatter.

If this sounds okay, I can also edit the documentation.
