### PR TITLE
Add possibility to compress log files with Zstandard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ all_components = [
 ]
 
 gzip = ["flate2"]
+zstandard = ["zstd"]
 
 [[bench]]
 name = "rotation"
@@ -58,6 +59,7 @@ harness = false
 arc-swap = "1.6"
 chrono = { version = "0.4.23", optional = true, features = ["clock"], default-features = false }
 flate2 = { version = "1.0", optional = true }
+zstd = { version = "0.13", optional = true }
 fnv = "1.0"
 humantime = { version = "2.1", optional = true }
 log = { version = "0.4.20", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ all_components = [
 ]
 
 gzip = ["flate2"]
-zstandard = ["zstd"]
+zstd = ["dep:zstd"]
 
 [[bench]]
 name = "rotation"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fn main() {
 ## Compression
 
 If you are using the file rotation in your configuration there is a known
-substantial performance issue with either the `gzip` or `zstandard`
+substantial performance issue with either the `gzip` or `zstd`
 features. When rolling files it will zip log archives automatically. This is
 a problem when the log archives are large as the zip process occurs in
 the main thread and will halt the process until the zip process
@@ -78,7 +78,7 @@ completes.
 The methods to mitigate this are as follows.
 
 1. Use the `background_rotation` feature which spawns an os thread to do the compression.
-2. Do not enable the `gzip` nor the `zstandard` features.
+2. Do not enable the `gzip` nor the `zstd` features.
 3. Ensure the archives are small enough that the compression time is acceptable.
 
 For more information see the PR that added [`background_rotation`](https://github.com/estk/log4rs/pull/117).

--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ fn main() {
 ## Compression
 
 If you are using the file rotation in your configuration there is a known
-substantial performance issue with the `gzip` feature. When rolling files 
-it will zip log archives automatically. This is a problem when the log archives
-are large as the zip happens in the main thread and will halt the process while
-the zip is completed.
-You might face the same issue also with the `zstandard` feature.
+substantial performance issue with either the `gzip` or `zstandard`
+features. When rolling files it will zip log archives automatically. This is
+a problem when the log archives are large as the zip process occurs in
+the main thread and will halt the process until the zip process
+completes.
 
 The methods to mitigate this are as follows.
 
 1. Use the `background_rotation` feature which spawns an os thread to do the compression.
-2. Do not enable neither the `gzip` nor the `zstandard` feature.
+2. Do not enable the `gzip` nor the `zstandard` features.
 3. Ensure the archives are small enough that the compression time is acceptable.
 
 For more information see the PR that added [`background_rotation`](https://github.com/estk/log4rs/pull/117).

--- a/README.md
+++ b/README.md
@@ -73,11 +73,12 @@ substantial performance issue with the `gzip` feature. When rolling files
 it will zip log archives automatically. This is a problem when the log archives
 are large as the zip happens in the main thread and will halt the process while
 the zip is completed.
+You might face the same issue also with the `zstandard` feature.
 
 The methods to mitigate this are as follows.
 
 1. Use the `background_rotation` feature which spawns an os thread to do the compression.
-2. Do not enable the `gzip` feature.
+2. Do not enable neither the `gzip` nor the `zstandard` feature.
 3. Ensure the archives are small enough that the compression time is acceptable.
 
 For more information see the PR that added [`background_rotation`](https://github.com/estk/log4rs/pull/117).

--- a/benches/rotation.rs
+++ b/benches/rotation.rs
@@ -63,7 +63,7 @@ fn mk_config(file_size: u64, file_count: u32) -> log4rs::config::Config {
     let roll_pattern = {
         if cfg!(feature = "gzip") {
             format!("{}/{}", log_path.to_string_lossy(), "log.{}.gz")
-        } else if cfg!(feature = "zstandard") {
+        } else if cfg!(feature = "zstd") {
             format!("{}/{}", log_path.to_string_lossy(), "log.{}.zst")
         } else {
             format!("{}/{}", log_path.to_string_lossy(), "log.{}")

--- a/benches/rotation.rs
+++ b/benches/rotation.rs
@@ -60,10 +60,15 @@ fn mk_config(file_size: u64, file_count: u32) -> log4rs::config::Config {
     let log_path = LOGDIR.path();
     let log_pattern = log_path.join("log.log");
 
-    #[cfg(feature = "gzip")]
-    let roll_pattern = format!("{}/{}", log_path.to_string_lossy(), "log.{}.gz");
-    #[cfg(not(feature = "gzip"))]
-    let roll_pattern = format!("{}/{}", log_path.to_string_lossy(), "log.{}");
+    let roll_pattern = {
+        if cfg!(feature = "gzip") {
+            format!("{}/{}", log_path.to_string_lossy(), "log.{}.gz")
+        } else if cfg!(feature = "zstandard") {
+            format!("{}/{}", log_path.to_string_lossy(), "log.{}.zst")
+        } else {
+            format!("{}/{}", log_path.to_string_lossy(), "log.{}")
+        }
+    };
 
     use log::LevelFilter;
     use log4rs::{

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -244,7 +244,7 @@ double curly brace `{}`. For example `archive/foo.{}.log`. Each instance of
 that if the file extension of the pattern is `.gz` and the `gzip` Cargo
 feature is enabled, the archive files will be gzip-compressed.
 If the file extension of the pattern is `.zst` and the `zstandard` Cargo
-feature is enabled, the archive files will be compressed the 
+feature is enabled, the archive files will be compressed using the 
 [Zstandard](https://facebook.github.io/zstd/) compression algorithm.
 
 > Note: This pattern field is only used for archived files. The `path` field

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -243,6 +243,9 @@ double curly brace `{}`. For example `archive/foo.{}.log`. Each instance of
 `{}` will be replaced with the index number of the configuration file. Note
 that if the file extension of the pattern is `.gz` and the `gzip` Cargo
 feature is enabled, the archive files will be gzip-compressed.
+If the file extension of the pattern is `.zst` and the `zstandard` Cargo
+feature is enabled, the archive files will be compressed the 
+[Zstandard](https://facebook.github.io/zstd/) compression algorithm.
 
 > Note: This pattern field is only used for archived files. The `path` field
 > of the higher level `rolling_file` will be used for the active log file.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -243,7 +243,7 @@ double curly brace `{}`. For example `archive/foo.{}.log`. Each instance of
 `{}` will be replaced with the index number of the configuration file. Note
 that if the file extension of the pattern is `.gz` and the `gzip` Cargo
 feature is enabled, the archive files will be gzip-compressed.
-If the file extension of the pattern is `.zst` and the `zstandard` Cargo
+If the file extension of the pattern is `.zst` and the `zstd` Cargo
 feature is enabled, the archive files will be compressed using the 
 [Zstandard](https://facebook.github.io/zstd/) compression algorithm.
 

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -31,7 +31,7 @@ enum Compression {
     None,
     #[cfg(feature = "gzip")]
     Gzip,
-    #[cfg(feature = "zstandard")]
+    #[cfg(feature = "zstd")]
     Zstd,
 }
 
@@ -56,7 +56,7 @@ impl Compression {
 
                 fs::remove_file(src)
             },
-            #[cfg(feature = "zstandard")]
+            #[cfg(feature = "zstd")]
             Compression::Zstd => {
                 use std::fs::File;
                 let mut i = File::open(src)?;
@@ -290,11 +290,11 @@ impl FixedWindowRollerBuilder {
             Some(e) if e == "gz" => {
                 bail!("gzip compression requires the `gzip` feature");
             },
-            #[cfg(feature = "zstandard")]
+            #[cfg(feature = "zstd")]
             Some(e) if e == "zst" => Compression::Zstd,
-            #[cfg(not(feature = "zstandard"))]
+            #[cfg(not(feature = "zstd"))]
             Some(e) if e == "zst" => {
-                bail!("zstd compression requires the `zstandard` feature");
+                bail!("zstd compression requires the `zstd` feature");
             },
             _ => Compression::None,
         };
@@ -582,7 +582,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(feature = "zstandard", ignore)]
+    #[cfg_attr(feature = "zstd", ignore)]
     fn unsupported_zstd() {
         let dir = tempfile::tempdir().unwrap();
 
@@ -593,11 +593,11 @@ mod test {
         assert!(roller
             .unwrap_err()
             .to_string()
-            .contains("zstd compression requires the `zstandard` feature"));
+            .contains("zstd compression requires the `zstd` feature"));
     }
 
     #[test]
-    #[cfg_attr(not(feature = "zstandard"), ignore)]
+    #[cfg_attr(not(feature = "zstd"), ignore)]
     // or should we force windows user to install zstd
     #[cfg(not(windows))]
     fn supported_zstd() {

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -587,9 +587,13 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
 
         let pattern = dir.path().join("{}.zst");
-        assert!(FixedWindowRoller::builder()
-            .build(pattern.to_str().unwrap(), 2)
-            .is_err());
+        let roller = FixedWindowRoller::builder()
+            .build(pattern.to_str().unwrap(), 2);
+        assert!(roller.is_err());
+        assert!(roller
+            .unwrap_err()
+            .to_string()
+            .contains("zstd compression requires the `zstandard` feature"));
     }
 
     #[test]

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -597,7 +597,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "zstd"), ignore)]
+    #[cfg(feature = "zstd")]
     fn supported_zstd() {
         let dir = tempfile::tempdir().unwrap();
 

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -55,7 +55,7 @@ impl Compression {
                 drop(i); // needs to happen before remove_file call on Windows
 
                 fs::remove_file(src)
-            },
+            }
             #[cfg(feature = "zstd")]
             Compression::Zstd => {
                 use std::fs::File;
@@ -289,13 +289,13 @@ impl FixedWindowRollerBuilder {
             #[cfg(not(feature = "gzip"))]
             Some(e) if e == "gz" => {
                 bail!("gzip compression requires the `gzip` feature");
-            },
+            }
             #[cfg(feature = "zstd")]
             Some(e) if e == "zst" => Compression::Zstd,
             #[cfg(not(feature = "zstd"))]
             Some(e) if e == "zst" => {
                 bail!("zstd compression requires the `zstd` feature");
-            },
+            }
             _ => Compression::None,
         };
 
@@ -587,8 +587,7 @@ mod test {
         let dir = tempfile::tempdir().unwrap();
 
         let pattern = dir.path().join("{}.zst");
-        let roller = FixedWindowRoller::builder()
-            .build(pattern.to_str().unwrap(), 2);
+        let roller = FixedWindowRoller::builder().build(pattern.to_str().unwrap(), 2);
         assert!(roller.is_err());
         assert!(roller
             .unwrap_err()

--- a/src/append/rolling_file/policy/compound/roll/fixed_window.rs
+++ b/src/append/rolling_file/policy/compound/roll/fixed_window.rs
@@ -598,11 +598,7 @@ mod test {
 
     #[test]
     #[cfg_attr(not(feature = "zstd"), ignore)]
-    // or should we force windows user to install zstd
-    #[cfg(not(windows))]
     fn supported_zstd() {
-        use std::process::Command;
-
         let dir = tempfile::tempdir().unwrap();
 
         let pattern = dir.path().join("{}.zst");
@@ -618,16 +614,8 @@ mod test {
         roller.roll(&file).unwrap();
         wait_for_roller(&roller);
 
-        assert!(Command::new("zstd")
-            .arg("-d")
-            .arg(dir.path().join("0.zst"))
-            .status()
-            .unwrap()
-            .success());
-
-        let mut file = File::open(dir.path().join("0")).unwrap();
-        let mut actual = vec![];
-        file.read_to_end(&mut actual).unwrap();
+        let compressed_data = fs::read(dir.path().join("0.zst")).unwrap();
+        let actual = zstd::decode_all(compressed_data.as_slice()).unwrap();
 
         assert_eq!(contents, actual);
     }


### PR DESCRIPTION
I would like to be able to compress log files with zstandard instead of gzip.