### PR TITLE
Support date/time in log file name

### DIFF
--- a/examples/sample_config.yml
+++ b/examples/sample_config.yml
@@ -8,7 +8,7 @@ appenders:
               level: info
     file:
         kind: file
-        path: "log/file.log"
+        path: "log/file-{d}.log"
         encoder:
             pattern: "[{d(%Y-%m-%dT%H:%M:%S%.6f)} {h({l}):<5.5} {M}] {m}{n}"
     rollingfile:

--- a/examples/sample_config.yml
+++ b/examples/sample_config.yml
@@ -8,7 +8,7 @@ appenders:
               level: info
     file:
         kind: file
-        path: "log/file-{d}.log"
+        path: "log/file-{%Y-%m-%d_%H-%M-%S}.log"
         encoder:
             pattern: "[{d(%Y-%m-%dT%H:%M:%S%.6f)} {h({l}):<5.5} {M}] {m}{n}"
     rollingfile:


### PR DESCRIPTION
Hi @estk,

As https://github.com/estk/log4rs/issues/242. I want to create a PR to apply date/time in log file name.
The path in file appender will be:

```
    path: "log/file-{%Y-%m-%d_%H-%M-%S}.log"
```

It has the same format with `chrono::datetime`