### PR TITLE
Drop MSRV to 1.65 and bump toml, mock_instant

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        rust_versions: ["stable", "1.69"]
+        rust_versions: ["stable", "1.65"]
         os: [ubuntu-latest, windows-latest]
     steps:
     - name: Checkout the source code
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust_versions: ["stable", "1.69"]
+        rust_versions: ["stable", "1.65"]
     steps:
     - name: Checkout the source code
       uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/estk/log4rs"
 readme = "README.md"
 keywords = ["log", "logger", "logging", "log4"]
 edition = "2018"
-rust-version = "1.69"
+rust-version = "1.65"
 
 [features]
 default = ["all_components", "config_parsing", "yaml_format"]
@@ -70,7 +70,7 @@ thread-id = { version = "4", optional = true }
 typemap-ors = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
-toml = { version = "<0.8.10", optional = true }
+toml = { version = "0.8.10", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 rand = { version = "0.8", optional = true}
 thiserror = "1.0.15"
@@ -89,7 +89,7 @@ lazy_static = "1.4"
 streaming-stats = "0.2.3"
 humantime = "2.1"
 tempfile = "3.8"
-mock_instant = "0.3"
+mock_instant = "0.5"
 serde_test = "1.0.176"
 
 [[example]]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/log4rs.svg)](https://crates.io/crates/log4rs)
 [![License: MIT OR Apache-2.0](https://img.shields.io/crates/l/clippy.svg)](#license)
 ![CI](https://github.com/estk/log4rs/workflows/CI/badge.svg)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.69+-green.svg)](https://github.com/estk/log4rs#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.65+-green.svg)](https://github.com/estk/log4rs#rust-version-requirements)
 
 log4rs is a highly configurable logging framework modeled after Java's Logback
 and log4j libraries.
@@ -54,7 +54,7 @@ fn main() {
 
 ## Rust Version Requirements
 
-1.69
+1.65
 
 ## Building for Dev
 

--- a/src/append/rolling_file/policy/compound/trigger/time.rs
+++ b/src/append/rolling_file/policy/compound/trigger/time.rs
@@ -6,7 +6,7 @@
 use chrono::NaiveDateTime;
 use chrono::{DateTime, Datelike, Duration, Local, TimeZone, Timelike};
 #[cfg(test)]
-use mock_instant::{SystemTime, UNIX_EPOCH};
+use mock_instant::global::{SystemTime, UNIX_EPOCH};
 use rand::Rng;
 #[cfg(feature = "config_parsing")]
 use serde::de;
@@ -340,7 +340,7 @@ impl Deserialize for TimeTriggerDeserializer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use mock_instant::MockClock;
+    use mock_instant::global::MockClock;
     use std::time::Duration;
 
     fn trigger_with_time_and_modulate(


### PR DESCRIPTION
As toml has drop their MSRV to 1.65(https://github.com/toml-rs/toml/pull/730), we could cancel the version limit of `toml` and drop our MSRV to 1.65 too.
