### PR TITLE
Made Handle accessible on logger enabling multilog environments

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,9 +27,7 @@ pub use self::raw::{Deserializable, Deserialize, Deserializers, RawConfig};
 pub fn init_config(config: runtime::Config) -> Result<crate::Handle, SetLoggerError> {
     let logger = crate::Logger::new(config);
     log::set_max_level(logger.max_log_level());
-    let handle = Handle {
-        shared: logger.0.clone(),
-    };
+    let handle = logger.handle();
     log::set_boxed_logger(Box::new(logger)).map(|()| handle)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,9 +464,7 @@ pub struct Handle {
 impl Handle {
     /// Sets the logging configuration.
     pub fn set_config(&self, config: Config) {
-        let shared = SharedLogger::new(config);
-        log::set_max_level(shared.root.max_log_level());
-        self.shared.store(Arc::new(shared));
+        self.reconfigure(config, EnvMode::Single)
     }
 
     /// Sets the logging configuration with optionally adjusting the global logger settings through the `log`` crate.
@@ -478,6 +476,11 @@ impl Handle {
             EnvMode::Multi => {}
         };
         self.shared.store(Arc::new(shared));
+    }
+
+    /// Get the maximum log level according to the current configuration
+    pub fn max_log_level(&self) -> LevelFilter {
+        self.shared.load().root.max_log_level()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,17 +464,8 @@ pub struct Handle {
 impl Handle {
     /// Sets the logging configuration.
     pub fn set_config(&self, config: Config) {
-        self.reconfigure(config, EnvMode::Single)
-    }
-
-    /// Sets the logging configuration with optionally adjusting the global logger settings through the `log`` crate.
-    /// (log::LOGGER and log::MAX_LOG_LEVEL_FILTER)
-    pub fn reconfigure(&self, config: Config, mode: EnvMode) {
         let shared = SharedLogger::new(config);
-        match mode {
-            EnvMode::Single => log::set_max_level(shared.root.max_log_level()),
-            EnvMode::Multi => {}
-        };
+        log::set_max_level(shared.root.max_log_level());
         self.shared.store(Arc::new(shared));
     }
 
@@ -482,14 +473,6 @@ impl Handle {
     pub fn max_log_level(&self) -> LevelFilter {
         self.shared.load().root.max_log_level()
     }
-}
-
-/// Logger environment mode used for reconfiguration
-pub enum EnvMode {
-    /// Log4rs is the only single logger set as the global logger, e.g. using `init_file`, `init_config` or `log::set_boxed_logger()
-    Single,
-    /// Log4rs is working besides other logger(s) and is NOT the global logger
-    Multi,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Based on the discussion in issue https://github.com/estk/log4rs/issues/390 this is a proof-of-concept experiment that enables using log4rs in a multilog environment.

Probably naming, documentation and others can still be improved a lot, what do you think?