### PR TITLE
Adding wasm as target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
-# The following is required for Wasm support in the `getrandom` crate, a transitive dependency of the `rand` crate.
-# See: https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support
+# The following is required for Wasm support in the `getrandom` crate, a transitive dependency of the `time_trigger`
+# feature. See: https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support
 #
 # If you are using `wasm-pack`, this config may not be respected. Use an environment variable instead:
 #       RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target web

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,7 @@
+# The following is required for Wasm support in the `getrandom` crate, a transitive dependency of the `rand` crate.
+# See: https://docs.rs/getrandom/0.3.3/getrandom/#webassembly-support
+#
+# If you are using `wasm-pack`, this config may not be respected. Use an environment variable instead:
+#       RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build --target web
+[target.wasm32-unknown-unknown]
+rustflags = ["--cfg", 'getrandom_backend="wasm_js"']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,3 +74,17 @@ jobs:
 
     - name: Bench features
       run: cargo bench --all-features
+
+  wasm:
+    name: Build for WebAssembly (wasm32-unknown-unknown)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source code
+      uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown
+
+    - name: Build for wasm32-unknown-unknown
+      run: cargo build --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,7 @@ winapi = { version = "0.3", optional = true, features = [
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2", optional = true }
 
-[target.'cfg(not(wasm))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 thread-id = { version = "4", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ libc = { version = "0.2", optional = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 thread-id = { version = "5", optional = true }
 
-[target.'cfg(target_family = "wasm")'.dependencies]
+[target.'cfg(all(target_family = "wasm", feature="time_trigger"))'.dependencies]
 getrandom = { version = "0.3.3", features = ["wasm_js"], optional = true }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ compound_policy = []
 delete_roller = []
 fixed_window_roller = []
 size_trigger = []
-time_trigger = ["rand"]
+time_trigger = ["rand", "getrandom"]
 json_encoder = [
     "serde",
     "serde_json",
@@ -85,7 +85,6 @@ log = { version = "0.4.21", features = ["std"] }
 log-mdc = { version = "0.1", optional = true }
 serde = { version = "1.0.196", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
-thread-id = { version = "5", optional = true }
 typemap-ors = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
@@ -111,7 +110,11 @@ winapi = { version = "0.3", optional = true, features = [
 libc = { version = "0.2", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-thread-id = { version = "4", optional = true }
+thread-id = { version = "5", optional = true }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { version = "0.3.3", features = ["wasm_js"], optional = true }
+
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,9 @@ winapi = { version = "0.3", optional = true, features = [
 [target.'cfg(not(windows))'.dependencies]
 libc = { version = "0.2", optional = true }
 
+[target.'cfg(not(wasm))'.dependencies]
+thread-id = { version = "4", optional = true }
+
 [dev-dependencies]
 lazy_static = "1.4"
 streaming-stats = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ The methods to mitigate this are as follows.
 
 For more information see the PR that added [`background_rotation`](https://github.com/estk/log4rs/pull/117).
 
+## Wasm Support
+
+If you are building this library for a Wasm target with the `time_trigger` feature enabled, you need to make
+sure the Rust flag `--cfg getrandom_backend="wasm_js"` is supplied to the compiler. This should be automatic when 
+compiling with Cargo, but some configurations and tooling might require you to set an environment variable:
+
+```bash
+export RUSTFLAGS='--cfg getrandom_backend="wasm_js"'
+```
+
 ## License
 
 Licensed under either of

--- a/src/encode/json.rs
+++ b/src/encode/json.rs
@@ -79,6 +79,7 @@ impl JsonEncoder {
             line: record.line(),
             target: record.target(),
             thread: thread.name(),
+            #[cfg(not(target_family = "wasm"))]
             thread_id: thread_id::get(),
             mdc: Mdc,
             #[cfg(feature = "log_kv")]
@@ -111,6 +112,7 @@ struct Message<'a> {
     line: Option<u32>,
     target: &'a str,
     thread: Option<&'a str>,
+    #[cfg(not(target_family = "wasm"))]
     thread_id: usize,
     mdc: Mdc,
     #[cfg(feature = "log_kv")]

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -158,6 +158,7 @@ use self::parser::Formatter;
 
 mod parser;
 
+#[cfg(not(target_family = "wasm"))]
 thread_local!(
     /// Thread-locally cached thread ID.
     static TID: usize = thread_id::get()
@@ -629,10 +630,18 @@ impl FormattedChunk {
             FormattedChunk::Thread => {
                 w.write_all(thread::current().name().unwrap_or("unnamed").as_bytes())
             }
+            #[cfg(not(target_family = "wasm"))]
             FormattedChunk::ThreadId => w.write_all(thread_id::get().to_string().as_bytes()),
+            #[cfg(target_family = "wasm")]
+            FormattedChunk::ThreadId => w.write_all("0".as_bytes()),
             FormattedChunk::ProcessId => w.write_all(process::id().to_string().as_bytes()),
+            #[cfg(not(target_family = "wasm"))]
             FormattedChunk::SystemThreadId => {
                 TID.with(|tid| w.write_all(tid.to_string().as_bytes()))
+            }
+            #[cfg(target_family = "wasm")]
+            FormattedChunk::SystemThreadId => {
+                w.write_all("0".as_bytes())
             }
             FormattedChunk::Target => w.write_all(record.target().as_bytes()),
             FormattedChunk::Newline => w.write_all(NEWLINE.as_bytes()),

--- a/src/encode/pattern/mod.rs
+++ b/src/encode/pattern/mod.rs
@@ -640,9 +640,7 @@ impl FormattedChunk {
                 TID.with(|tid| w.write_all(tid.to_string().as_bytes()))
             }
             #[cfg(target_family = "wasm")]
-            FormattedChunk::SystemThreadId => {
-                w.write_all("0".as_bytes())
-            }
+            FormattedChunk::SystemThreadId => w.write_all("0".as_bytes()),
             FormattedChunk::Target => w.write_all(record.target().as_bytes()),
             FormattedChunk::Newline => w.write_all(NEWLINE.as_bytes()),
             FormattedChunk::Align(ref chunks) => {

--- a/src/encode/writer/console.rs
+++ b/src/encode/writer/console.rs
@@ -250,14 +250,8 @@ mod imp {
         pub fn stdout() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stdout()));
             match *COLOR_MODE {
-                ColorMode::Auto => {
-                    if unsafe { libc::isatty(libc::STDOUT_FILENO) } != 1 {
-                        None
-                    } else {
-                        Some(writer())
-                    }
-                }
-                ColorMode::Always => Some(writer()),
+                ColorMode::Auto 
+                | ColorMode::Always => Some(writer()),
                 ColorMode::Never => None,
             }
         }
@@ -265,14 +259,8 @@ mod imp {
         pub fn stderr() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stderr()));
             match *COLOR_MODE {
-                ColorMode::Auto => {
-                    if unsafe { libc::isatty(libc::STDERR_FILENO) } != 1 {
-                        None
-                    } else {
-                        Some(writer())
-                    }
-                }
-                ColorMode::Always => Some(writer()),
+                ColorMode::Auto 
+                | ColorMode::Always => Some(writer()),
                 ColorMode::Never => None,
             }
         }

--- a/src/encode/writer/console.rs
+++ b/src/encode/writer/console.rs
@@ -237,7 +237,7 @@ mod imp {
             self,
             writer::{
                 ansi::AnsiWriter,
-                console::{ColorMode, COLOR_MODE},
+                console::{color_mode, ColorMode},
             },
             Style,
         },
@@ -249,18 +249,16 @@ mod imp {
     impl Writer {
         pub fn stdout() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stdout()));
-            match *COLOR_MODE {
-                ColorMode::Auto 
-                | ColorMode::Always => Some(writer()),
+            match color_mode() {
+                ColorMode::Auto | ColorMode::Always => Some(writer()),
                 ColorMode::Never => None,
             }
         }
 
         pub fn stderr() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stderr()));
-            match *COLOR_MODE {
-                ColorMode::Auto 
-                | ColorMode::Always => Some(writer()),
+            match color_mode() {
+                ColorMode::Auto | ColorMode::Always => Some(writer()),
                 ColorMode::Never => None,
             }
         }


### PR DESCRIPTION
This builds upon the work of @upendra1997. The following work was stacked upon his original PR #407:

- Reorganized target-specific dependencies.
- Rebased onto main.
- Removed `libc::isatty` tests in the `Writer` impl in `console.rs`.
- Added `.cargo/config.toml` to tell Cargo to use the `--cfg getrandom_backend="wasm_js"` Rust flag, required for the `rand`/`getrandom` dependencies.
- Added a blurb in the README.md about the need for the above Rust flags.

~This is a DRAFT until the following questions are resolved:~ See discussion below.

- ~`getrandom`, a transitive dependency of the `rand` crate, requires special treatment for a Wasm target. However, `rand` is only included if the `time_trigger` feature is enabled, which it is by default. Does this feature make sense for Wasm targets? If not, we can remove the `getrandom`-specific parts of this PR.~
- ~What other features don't make sense for the Wasm target? We should exclude them and their dependencies for Wasm targets.~
- ~Someone should verify that removing the `unsafe { libc::isatty(libc::STDOUT_FILENO) } != 1` checks is the right thing to do.~