### PR TITLE
feat: remove oncecell dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ rand = { version = "0.9", optional = true }
 thiserror = "2.0.12"
 anyhow = "1.0.28"
 derive_more = { version = "2.0.1", features = ["debug"] }
-once_cell = "1.17.1"
 mock_instant = "0.5"
 unicode-segmentation = "1.10.0"
 

--- a/src/encode/writer/console.rs
+++ b/src/encode/writer/console.rs
@@ -5,30 +5,34 @@
 use std::{fmt, io};
 
 use crate::encode::{self, Style};
-use once_cell::sync::Lazy;
+use std::sync::OnceLock;
 
-static COLOR_MODE: Lazy<ColorMode> = Lazy::new(|| {
-    let no_color = std::env::var("NO_COLOR")
-        .map(|var| var != "0")
-        .unwrap_or(false);
-    let clicolor_force = std::env::var("CLICOLOR_FORCE")
-        .map(|var| var != "0")
-        .unwrap_or(false);
-    if no_color {
-        ColorMode::Never
-    } else if clicolor_force {
-        ColorMode::Always
-    } else {
-        let clicolor = std::env::var("CLICOLOR")
+static COLOR_MODE: OnceLock<ColorMode> = OnceLock::new();
+
+fn color_mode() -> &'static ColorMode {
+    COLOR_MODE.get_or_init(|| {
+        let no_color = std::env::var("NO_COLOR")
             .map(|var| var != "0")
-            .unwrap_or(true);
-        if clicolor {
-            ColorMode::Auto
-        } else {
+            .unwrap_or(false);
+        let clicolor_force = std::env::var("CLICOLOR_FORCE")
+            .map(|var| var != "0")
+            .unwrap_or(false);
+        if no_color {
             ColorMode::Never
+        } else if clicolor_force {
+            ColorMode::Always
+        } else {
+            let clicolor = std::env::var("CLICOLOR")
+                .map(|var| var != "0")
+                .unwrap_or(true);
+            if clicolor {
+                ColorMode::Auto
+            } else {
+                ColorMode::Never
+            }
         }
-    }
-});
+    })
+}
 
 /// The color output mode for a `ConsoleAppender`
 #[derive(Clone, Copy, Default)]
@@ -128,7 +132,7 @@ mod imp {
             self,
             writer::{
                 ansi::AnsiWriter,
-                console::{ColorMode, COLOR_MODE},
+                console::{ColorMode, color_mode},
             },
             Style,
         },
@@ -140,7 +144,7 @@ mod imp {
     impl Writer {
         pub fn stdout() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stdout()));
-            match *COLOR_MODE {
+            match color_mode() {
                 ColorMode::Auto => {
                     if unsafe { libc::isatty(libc::STDOUT_FILENO) } != 1 {
                         None
@@ -155,7 +159,7 @@ mod imp {
 
         pub fn stderr() -> Option<Writer> {
             let writer = || Writer(AnsiWriter(StdWriter::stderr()));
-            match *COLOR_MODE {
+            match color_mode() {
                 ColorMode::Auto => {
                     if unsafe { libc::isatty(libc::STDERR_FILENO) } != 1 {
                         None
@@ -239,7 +243,7 @@ mod imp {
     use crate::{
         encode::{
             self,
-            writer::console::{ColorMode, COLOR_MODE},
+            writer::console::{ColorMode, color_mode},
             Color, Style,
         },
         priv_io::{StdWriter, StdWriterLock},
@@ -335,7 +339,7 @@ mod imp {
                     inner: StdWriter::stdout(),
                 };
 
-                match *COLOR_MODE {
+                match color_mode() {
                     ColorMode::Auto | ColorMode::Always => Some(writer),
                     ColorMode::Never => None,
                 }
@@ -362,7 +366,7 @@ mod imp {
                     inner: StdWriter::stdout(),
                 };
 
-                match *COLOR_MODE {
+                match color_mode() {
                     ColorMode::Auto | ColorMode::Always => Some(writer),
                     ColorMode::Never => None,
                 }

--- a/src/encode/writer/console.rs
+++ b/src/encode/writer/console.rs
@@ -132,7 +132,7 @@ mod imp {
             self,
             writer::{
                 ansi::AnsiWriter,
-                console::{ColorMode, color_mode},
+                console::{color_mode, ColorMode},
             },
             Style,
         },
@@ -243,7 +243,7 @@ mod imp {
     use crate::{
         encode::{
             self,
-            writer::console::{ColorMode, color_mode},
+            writer::console::{color_mode, ColorMode},
             Color, Style,
         },
         priv_io::{StdWriter, StdWriterLock},


### PR DESCRIPTION
Seeing that in the most recent RC release the MSRV has been bumped to 1.75, we can now use [OnceLock](https://doc.rust-lang.org/beta/std/sync/struct.OnceLock.html) which is available in 1.70 thus getting rid of the `OnceCell` dependency.

Tests fail locally, but they do the same on `main` currently.

Might be related to #365