### PR TITLE
Bugfix: On windows stderr was erroneously written to stdout

### DIFF
--- a/src/encode/writer/console.rs
+++ b/src/encode/writer/console.rs
@@ -363,7 +363,7 @@ mod imp {
                         handle,
                         defaults: info.wAttributes,
                     },
-                    inner: StdWriter::stdout(),
+                    inner: StdWriter::stderr(),
                 };
 
                 match color_mode() {


### PR DESCRIPTION
I think a copy paste issue caused this with commit 4f09b8fd5e47dbccfe64ef91a464194b0e8ed053. It's been there a while