### PR TITLE
chore(deps): replace unmaintained serde_yaml crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ config_parsing = [
     "typemap-ors",
     "log/serde",
 ]
-yaml_format = ["serde_yaml"]
+yaml_format = ["serde-saphyr"]
 json_format = ["serde_json"]
 toml_format = ["toml"]
 console_appender = ["console_writer", "simple_writer", "pattern_encoder"]
@@ -87,7 +87,7 @@ serde = { version = "1.0.196", optional = true, features = ["derive"] }
 serde-value = { version = "0.7", optional = true }
 typemap-ors = { version = "1.0.0", optional = true }
 serde_json = { version = "1.0", optional = true }
-serde_yaml = { version = "0.9", optional = true }
+serde-saphyr = { version = "0.0.7", optional = true }
 toml = { version = "<0.8.10", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 rand = { version = "0.9", optional = true }

--- a/examples/compile_time_config.rs
+++ b/examples/compile_time_config.rs
@@ -2,7 +2,7 @@ use log::{error, info, trace};
 
 fn main() {
     let config_str = include_str!("sample_config.yml");
-    let config = serde_yaml::from_str(config_str).unwrap();
+    let config = serde_saphyr::from_str(config_str).unwrap();
     log4rs::init_raw_config(config).unwrap();
 
     info!("Goes to console, file and rolling file");

--- a/src/append/rolling_file/mod.rs
+++ b/src/append/rolling_file/mod.rs
@@ -410,7 +410,7 @@ appenders:
             dir.path().display()
         );
 
-        let config = ::serde_yaml::from_str::<RawConfig>(&config).unwrap();
+        let config = ::serde_saphyr::from_str::<RawConfig>(&config).unwrap();
         let errors = config.appenders_lossy(&Deserializers::new()).1;
         println!("{:?}", errors);
         assert!(errors.is_empty());

--- a/src/append/rolling_file/policy/compound/trigger/time.rs
+++ b/src/append/rolling_file/policy/compound/trigger/time.rs
@@ -453,7 +453,7 @@ mod test {
         ];
 
         for interval in test_error.iter() {
-            let error = ::serde_yaml::from_str::<TimeTriggerInterval>(interval);
+            let error = ::serde_saphyr::from_str::<TimeTriggerInterval>(interval);
             assert!(error.is_err());
         }
 
@@ -484,7 +484,7 @@ mod test {
         ];
         for (interval, expected) in test_ok.iter() {
             let interval = interval.to_string();
-            let interval = ::serde_yaml::from_str::<TimeTriggerInterval>(&interval).unwrap();
+            let interval = ::serde_saphyr::from_str::<TimeTriggerInterval>(&interval).unwrap();
             assert_eq!(interval, *expected);
         }
     }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -129,7 +129,7 @@ impl Format {
     fn parse(&self, source: &str) -> anyhow::Result<RawConfig> {
         match *self {
             #[cfg(feature = "yaml_format")]
-            Format::Yaml => ::serde_yaml::from_str(source).map_err(Into::into),
+            Format::Yaml => ::serde_saphyr::from_str(source).map_err(Into::into),
             #[cfg(feature = "json_format")]
             Format::Json => ::serde_json::from_str(source).map_err(Into::into),
             #[cfg(feature = "toml_format")]

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -512,7 +512,7 @@ loggers:
             - baz
         additive: false
 "#;
-        let config = ::serde_yaml::from_str::<RawConfig>(cfg).unwrap();
+        let config = ::serde_saphyr::from_str::<RawConfig>(cfg).unwrap();
         let errors = config.appenders_lossy(&Deserializers::new()).1;
         println!("{:?}", errors);
         assert!(errors.is_empty());
@@ -521,7 +521,7 @@ loggers:
     #[test]
     #[cfg(feature = "yaml_format")]
     fn empty() {
-        ::serde_yaml::from_str::<RawConfig>("{}").unwrap();
+        ::serde_saphyr::from_str::<RawConfig>("{}").unwrap();
     }
 
     #[cfg(windows)]
@@ -545,7 +545,7 @@ loggers:
         let config_end = sample_file.find(&config_end_string).unwrap();
         let config_str = sample_file[config_start..config_end].trim();
 
-        let config = ::serde_yaml::from_str::<RawConfig>(config_str);
+        let config = ::serde_saphyr::from_str::<RawConfig>(config_str);
         assert!(config.is_ok());
         assert!(config::create_raw_config(config.unwrap()).is_ok());
     }


### PR DESCRIPTION
[serde-saphyr](https://crates.io/crates/serde-saphyr) is actively maintained, does not depend on `indexmap`, and is free of unsafe code.